### PR TITLE
Catch consumer coordinator not available when using dual offset fetch…

### DIFF
--- a/kafka_tools/util/monitoring.py
+++ b/kafka_tools/util/monitoring.py
@@ -1,6 +1,7 @@
 import logging
 from collections import namedtuple
 
+from kafka.common import ConsumerCoordinatorNotAvailableCode
 from kafka.common import KafkaUnavailableError
 
 from kafka_tools.util.error import InvalidOffsetStorageError
@@ -111,9 +112,12 @@ def _get_current_offsets_dual(
     zk_offsets = get_current_consumer_offsets(
         kafka_client, group, topics, False, 'zookeeper',
     )
-    kafka_offsets = get_current_consumer_offsets(
-        kafka_client, group, topics, False, 'kafka',
-    )
+    try:
+        kafka_offsets = get_current_consumer_offsets(
+            kafka_client, group, topics, False, 'kafka',
+        )
+    except ConsumerCoordinatorNotAvailableCode:
+        kafka_offsets = {}
     return merge_offsets_metadata(topics, zk_offsets, kafka_offsets)
 
 

--- a/tests/util/test_monitoring.py
+++ b/tests/util/test_monitoring.py
@@ -1,5 +1,6 @@
 import mock
 import pytest
+from kafka.common import ConsumerCoordinatorNotAvailableCode
 from kafka.common import KafkaUnavailableError
 from test_offsets import MyKafkaClient
 from test_offsets import TestOffsetsBase
@@ -224,6 +225,29 @@ class TestMonitoring(TestOffsetsBase):
             MyKafkaClient,
             'send_offset_fetch_request_kafka',
             return_value={},
+            autospec=True,
+        ) as mock_get_kafka:
+            actual = get_consumer_offsets_metadata(
+                kafka_client_mock,
+                self.group,
+                self.topics,
+                offset_storage='dual',
+            )
+
+            assert mock_get_zk.call_count == 1
+            assert mock_get_kafka.call_count == 1
+            assert self._has_no_partitions(actual)
+
+    def test_dual_offsets_kafka_error(self, kafka_client_mock):
+        with mock.patch.object(
+            MyKafkaClient,
+            'send_offset_fetch_request',
+            return_value={},
+            autospec=True,
+        ) as mock_get_zk, mock.patch.object(
+            MyKafkaClient,
+            'send_offset_fetch_request_kafka',
+            side_effect=ConsumerCoordinatorNotAvailableCode('Boom!'),
             autospec=True,
         ) as mock_get_kafka:
             actual = get_consumer_offsets_metadata(


### PR DESCRIPTION
…, and kafka has no coordinator.

The offset_get command uses storage='dual' by default.

This causes the command to fail when the offsets are not stored in kafka.
