### PR TITLE
Sleep and retry produce message when leader not available for a creat…

### DIFF
--- a/tests/acceptance/steps/util.py
+++ b/tests/acceptance/steps/util.py
@@ -5,6 +5,7 @@ import uuid
 from kafka import KafkaClient
 from kafka import KafkaConsumer
 from kafka import SimpleProducer
+from kafka.common import LeaderNotAvailableError
 
 from kafka_tools.util import config
 
@@ -63,7 +64,11 @@ def produce_example_msg(topic, num_messages=1):
     kafka = KafkaClient(KAFKA_URL)
     producer = SimpleProducer(kafka)
     for i in xrange(num_messages):
-        producer.send_messages(topic, b'some message')
+        try:
+            producer.send_messages(topic, b'some message')
+        except LeaderNotAvailableError:
+            time.sleep(1)
+            producer.send_messages(topic, b'some message')
 
 
 def create_consumer_group(topic, group_name, num_messages=1):


### PR DESCRIPTION
…ed topic in acceptance tests.

This should eliminate the LeaderNotAvailableError errors that break acceptance tests.
