### PR TITLE
Refactor configuration loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Broker as leaders distribution
 Configuration of kafka-clusters
 -------------------------------
 
-The cluster configuration is set-up by default from yaml files at /nail/etc/kafka_discovery as <cluster-type>.yaml files
+The cluster configuration is set-up by default from yaml files at /etc/kafka_discovery as <cluster-type>.yaml files
 
 Sample configuration for scribe cluster at /nail/etc/kafka_discovery/scribe.yaml
 

--- a/kafka_tools/util/error.py
+++ b/kafka_tools/util/error.py
@@ -25,6 +25,16 @@ class ConfigurationError(KafkaToolError):
     pass
 
 
+class MissingConfigurationError(ConfigurationError):
+    """Missing configuration file."""
+    pass
+
+
+class InvalidConfigurationError(ConfigurationError):
+    """Invalid configuration file."""
+    pass
+
+
 class InvalidOffsetStorageError(KafkaToolError):
     """Unknown source of offsets."""
     pass

--- a/tests/util/config_test.py
+++ b/tests/util/config_test.py
@@ -282,8 +282,8 @@ class TestTopologyConfig(object):
             topology.get_cluster_by_name('does-not-exist')
 
     def test___eq__(self, mock_yaml):
-        topology1 = TopologyConfiguration("mykafka", "/nail/etc/kafka_discovery")
-        topology2 = TopologyConfiguration("mykafka", "/nail/etc/kafka_discovery")
+        topology1 = TopologyConfiguration("mykafka", "/etc/kafka_discovery")
+        topology2 = TopologyConfiguration("mykafka", "/etc/kafka_discovery")
         assert topology1 == topology2
 
         topology1 = TopologyConfiguration("mykafka")
@@ -291,8 +291,8 @@ class TestTopologyConfig(object):
         assert topology1 == topology2
 
     def test___ne__(self, mock_yaml):
-        topology1 = TopologyConfiguration("mykafka", "/nail/etc/kafka_discovery")
-        topology2 = TopologyConfiguration("somethingelse", "/nail/etc/kafka_discovery")
+        topology1 = TopologyConfiguration("mykafka", "/etc/kafka_discovery")
+        topology2 = TopologyConfiguration("somethingelse", "/etc/kafka_discovery")
         assert topology1 != topology2
 
         topology1 = TopologyConfiguration("mykafka")


### PR DESCRIPTION
Changed configuration lookup (but still support the cli option). Topology lookup in order of priority:
- $KAFKA_DISCOVERY_DIR env variable
- $HOME/.kafka_discovery
- /etc/kafka_discovery

Removed error message from kafka-tools when there are is no configuration available. 
