### PR TITLE
Fix bug for No available brokers to move partition to

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+0.1.2 (June 8, 2016)
+----------------------
+* Fix bug for no available under-loaded brokers
+
 0.1.1 (May 17, 2016)
 ----------------------
 

--- a/kafka_utils/__init__.py
+++ b/kafka_utils/__init__.py
@@ -12,4 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '0.1.1'
+__version__ = '0.1.2'

--- a/kafka_utils/kafka_cluster_manager/cluster_info/rg.py
+++ b/kafka_utils/kafka_cluster_manager/cluster_info/rg.py
@@ -369,14 +369,17 @@ class ReplicationGroup(object):
         )
 
         # Get source and destination broker
-        source_broker = max(
-            over_brokers,
-            key=lambda broker: len(broker.partitions),
-        )
-        dest_broker = min(
-            under_brokers,
-            key=lambda broker: len(broker.partitions),
-        )
+        source_broker, dest_broker = None, None
+        if over_brokers:
+            source_broker = max(
+                over_brokers,
+                key=lambda broker: len(broker.partitions),
+            )
+        if under_brokers:
+            dest_broker = min(
+                under_brokers,
+                key=lambda broker: len(broker.partitions),
+            )
         return (source_broker, dest_broker)
 
     def __str__(self):

--- a/tests/kafka_cluster_manager/cluster_topology_test.py
+++ b/tests/kafka_cluster_manager/cluster_topology_test.py
@@ -804,6 +804,25 @@ class TestClusterTopology(object):
         # Verify replica-count imbalance remains 0
         assert net_imbal == 0
 
+    def test__rebalance_groups_partition_cnt_case4(self):
+        # rg1 has 4 partitions
+        # rg2 has 2 partitions
+        # Both rg's are balanced(based on replica-count) initially
+        # Result: rg's couldn't be balanced partition-count since
+        # no available broker without partition movement
+        assignment = dict(
+            [
+                ((u'T1', 1), ['0', '1', '2']),
+                ((u'T2', 0), ['0', '1', '2']),
+            ]
+        )
+        ct = self.build_cluster_topology(assignment, self.srange(3))
+        # Re-balance replication-groups for partition-count
+        ct._rebalance_groups_partition_cnt()
+
+        # Verify no change in assignment
+        assert ct.assignment == assignment
+
     def test_update_cluster_topology_invalid_broker(self):
         assignment = dict([((u'T0', 0), ['1', '2'])])
         new_assignment = dict([((u'T0', 0), ['1', '3'])])


### PR DESCRIPTION
If there are no available brokers with destination broker for eligible partition (because all brokers already have a replica for the same) it should return None. 