### PR TITLE
Fix logging in kafka cluster manager

### DIFF
--- a/kafka_utils/kafka_cluster_manager/main.py
+++ b/kafka_utils/kafka_cluster_manager/main.py
@@ -132,7 +132,7 @@ def parse_args():
 def configure_logging(log_conf=None):
     if log_conf:
         try:
-            fileConfig(log_conf)
+            fileConfig(log_conf, disable_existing_loggers=False)
         except ConfigParser.NoSectionError:
             logging.basicConfig(level=logging.INFO)
             _log.error(


### PR DESCRIPTION
By default fileConfig disables all loggers that are define before it is called. Most of our loggers are defined during application start and get disabled. This change prevent fileConfig from disabling them.