### PR TITLE
Fix logging bug when rg is None

### DIFF
--- a/kafka_utils/kafka_cluster_manager/cmds/rebalance.py
+++ b/kafka_utils/kafka_cluster_manager/cmds/rebalance.py
@@ -106,7 +106,7 @@ class RebalanceCmd(ClusterManagerCmd):
         if self.args.replication_groups:
             self.log.info(
                 'Re-balancing replica-count over replication groups: %s',
-                ', '.join(ct.rgs.keys()),
+                ', '.join([str(rg) for rg in ct.rgs.keys()]),
             )
             ct.rebalance_replication_groups()
 


### PR DESCRIPTION
The replication group map can contain None keys when a broker is down. This should trigger a RebalanceError, but this logging line will fail first. This change will make sure that the logging line won't fail in presence of None values.