### PR TITLE
Ensure kafka-cluster-manager commands exit cleanly on empty clusters

### DIFF
--- a/kafka_utils/kafka_cluster_manager/cmds/command.py
+++ b/kafka_utils/kafka_cluster_manager/cmds/command.py
@@ -68,6 +68,9 @@ class ClusterManagerCmd(object):
                 brokers,
                 rg_parser.get_replication_group,
             )
+            if len(ct.partitions) == 0:
+                self.log.info("The cluster is empty. No actions to perform.")
+                return
             self.run_command(ct)
 
     def add_subparser(self, subparsers):

--- a/tests/kafka_cluster_manager/cmds/command_test.py
+++ b/tests/kafka_cluster_manager/cmds/command_test.py
@@ -288,6 +288,7 @@ class TestClusterManagerCmd(object):
         )
         rg_parser = mock.MagicMock()
         cmd.run_command = mock.MagicMock()
+
         cmd.run(cluster_config, rg_parser, args)
 
         assert cmd.run_command.call_count == 0

--- a/tests/kafka_cluster_manager/cmds/command_test.py
+++ b/tests/kafka_cluster_manager/cmds/command_test.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 from collections import OrderedDict
 
+import mock
 from pytest import fixture
 
 from kafka_utils.kafka_cluster_manager.cmds.command import ClusterManagerCmd
@@ -272,3 +273,21 @@ class TestClusterManagerCmd(object):
         # T1 no changes for 0
         assert (u'T1', 0) not in result and (u'T1', 1) in result
         assert (u'T0', 0) in result and (u'T0', 1) in result
+
+    @mock.patch('kafka_utils.kafka_cluster_manager.cmds.command.ZK')
+    def test_empty_cluster(self, mock_zk, cmd):
+        cluster_config = mock.MagicMock()
+        args = mock.MagicMock()
+        mock_zk.return_value = mock.MagicMock(
+            get_brokers=lambda: {
+                1: {'host': 'host1'},
+                2: {'host': 'host2'},
+                3: {'host': 'host3'},
+            },
+            get_assignment=lambda: {},
+        )
+        rg_parser = mock.MagicMock()
+        cmd.run_command = mock.MagicMock()
+        cmd.run(cluster_config, rg_parser, args)
+
+        assert cmd.run_command.call_count == 0


### PR DESCRIPTION
Some of the kafka-cluster-manager sub-commands (`rebalance`, `decommission`, `move-brokers`) fail with exit status `1` when there are no topics in the cluster. An empty cluster is not be an error so the exit status should be `0`. This is true for all sub-commands so we can make this change globally.