### PR TITLE
Add set_replication_factor sub-command to kafka-cluster-manager

### DIFF
--- a/kafka_utils/kafka_cluster_manager/cluster_info/cluster_topology.py
+++ b/kafka_utils/kafka_cluster_manager/cluster_info/cluster_topology.py
@@ -486,7 +486,8 @@ class ClusterTopology(object):
         """
         if partition.replication_factor + count > len(self.brokers):
             raise InvalidReplicationFactorError(
-                "Replication factor {0} is greater than the broker count {1}"
+                "Cannot increase replication factor to {0}. There are only "
+                "{1} brokers."
                 .format(
                     partition.replication_factor + count,
                     len(self.brokers),
@@ -546,8 +547,8 @@ class ClusterTopology(object):
         """
         if partition.replication_factor <= count:
             raise InvalidReplicationFactorError(
-                "Replication factor {} is less than 1."
-                .format(partition.replication_factor - count)
+                "Cannot remove {0} replicas. Replication factor is only {1}."
+                .format(count, partition.replication_factor)
             )
 
         non_empty_rgs = [

--- a/kafka_utils/kafka_cluster_manager/cluster_info/error.py
+++ b/kafka_utils/kafka_cluster_manager/cluster_info/error.py
@@ -20,8 +20,20 @@ class InvalidBrokerIdError(KafkaToolError):
     pass
 
 
+class InvalidBrokerError(KafkaToolError):
+    """Raised when a broker doesn't exist within a replication-group."""
+    pass
+
+
 class InvalidPartitionError(KafkaToolError):
     """Raised when a partition tuple (topic, partition) doesn't exist in the cluster"""
+    pass
+
+
+class InvalidReplicationFactorError(KafkaToolError):
+    """Raised when an operation would result in an replication factor that is
+    too small or too large for the cluster.
+    """
     pass
 
 

--- a/kafka_utils/kafka_cluster_manager/cluster_info/error.py
+++ b/kafka_utils/kafka_cluster_manager/cluster_info/error.py
@@ -20,11 +20,6 @@ class InvalidBrokerIdError(KafkaToolError):
     pass
 
 
-class InvalidBrokerError(KafkaToolError):
-    """Raised when a broker doesn't exist within a replication-group."""
-    pass
-
-
 class InvalidPartitionError(KafkaToolError):
     """Raised when a partition tuple (topic, partition) doesn't exist in the cluster"""
     pass

--- a/kafka_utils/kafka_cluster_manager/cluster_info/rg.py
+++ b/kafka_utils/kafka_cluster_manager/cluster_info/rg.py
@@ -383,6 +383,28 @@ class ReplicationGroup(object):
             )
         return (source_broker, dest_broker)
 
+    def add_replica(self, partition):
+        broker = self._elect_dest_broker(partition)
+        self.log.debug(
+            'Adding partition {p_name} to broker {broker}'
+            .format(
+                p_name=partition.name,
+                broker=broker.id,
+            ),
+        )
+        broker.add_partition(partition)
+
+    def remove_replica(self, partition):
+        broker = self._elect_source_broker(partition)
+        self.log.debug(
+            'Removing partition {p_name} from broker {broker}'
+            .format(
+                p_name=partition.name,
+                broker=broker.id,
+            ),
+        )
+        broker.remove_partition(partition)
+
     def __str__(self):
         return "{0}".format(self._id)
 

--- a/kafka_utils/kafka_cluster_manager/cluster_info/rg.py
+++ b/kafka_utils/kafka_cluster_manager/cluster_info/rg.py
@@ -17,7 +17,6 @@ import sys
 from collections import defaultdict
 
 from .error import EmptyReplicationGroupError
-from .error import InvalidBrokerError
 from .error import NotEligibleGroupError
 from .util import separate_groups
 
@@ -397,12 +396,8 @@ class ReplicationGroup(object):
         broker.add_partition(partition)
 
     def remove_replica(self, partition, broker_subset=None):
-        for broker in broker_subset:
-            if broker not in self.brokers:
-                raise InvalidBrokerError(
-                    "Broker {0} can not be found in replication group {1}."
-                    .format(broker, self)
-                )
+        assert not any(broker not in self.brokers for broker in broker_subset)
+
         broker = self._elect_source_broker(partition, broker_subset)
         self.log.debug(
             'Removing partition {p_name} from broker {broker}'

--- a/kafka_utils/kafka_cluster_manager/cmds/command.py
+++ b/kafka_utils/kafka_cluster_manager/cmds/command.py
@@ -73,14 +73,14 @@ class ClusterManagerCmd(object):
     def add_subparser(self, subparsers):
         self.build_subparser(subparsers).set_defaults(command=self.run)
 
-    def execute_plan(self, plan):
+    def execute_plan(self, plan, allow_rf_change=False):
         """Save proposed-plan and execute the same if requested."""
         if self.should_execute():
             # Exit if there is an on-going reassignment
             if self.is_reassignment_pending():
                 self.log.error('Previous reassignment pending.')
                 sys.exit(1)
-            result = self.zk.execute_plan(plan)
+            result = self.zk.execute_plan(plan, allow_rf_change=allow_rf_change)
             if not result:
                 self.log.error('Plan execution unsuccessful.')
                 sys.exit(1)
@@ -106,6 +106,17 @@ class ClusterManagerCmd(object):
             raise argparse.ArgumentTypeError(error_msg)
         return value
 
+    def positive_nonzero_int(self, string):
+        """Convert string to positive integer greater than zero."""
+        error_msg = 'Positive non-zero integer required, {string} given.'.format(string=string)
+        try:
+            value = int(string)
+        except ValueError:
+            raise argparse.ArgumentTypeError(error_msg)
+        if value <= 0:
+            raise argparse.ArgumentTypeError(error_msg)
+        return value
+
     def is_reassignment_pending(self):
         """Return True if there are no reassignment tasks pending."""
         in_progress_plan = self.zk.get_pending_plan()
@@ -123,7 +134,7 @@ class ClusterManagerCmd(object):
         else:
             return False
 
-    def process_assignment(self, assignment):
+    def process_assignment(self, assignment, allow_rf_change=False):
         plan = assignment_to_plan(assignment)
         if self.args.proposed_plan_file:
             self.log.info(
@@ -139,7 +150,7 @@ class ClusterManagerCmd(object):
             'Proposed-plan actions count: %s',
             len(plan['partitions']),
         )
-        self.execute_plan(plan)
+        self.execute_plan(plan, allow_rf_change=allow_rf_change)
 
     def get_reduced_assignment(
         self,

--- a/kafka_utils/kafka_cluster_manager/cmds/set_replication_factor.py
+++ b/kafka_utils/kafka_cluster_manager/cmds/set_replication_factor.py
@@ -125,7 +125,8 @@ class SetReplicationFactorCmd(ClusterManagerCmd):
         reduced_assignment = self.get_reduced_assignment(
             base_assignment,
             assignment,
-            max_partition_movements=1,
-            max_leader_only_changes=1,
+            # Only the partitions of the chosen topic should change.
+            max_partition_movements=len(topic.partitions),
+            max_leader_only_changes=len(topic.partitions),
         )
         self.process_assignment(reduced_assignment, allow_rf_change=True)

--- a/kafka_utils/kafka_cluster_manager/cmds/set_replication_factor.py
+++ b/kafka_utils/kafka_cluster_manager/cmds/set_replication_factor.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import sys
+
+from .command import ClusterManagerCmd
+
+
+class SetReplicationFactorCmd(ClusterManagerCmd):
+
+    def __init__(self):
+        super(SetReplicationFactorCmd, self).__init__()
+        self.log = logging.getLogger(self.__class__.__name__)
+
+    def build_subparser(self, subparsers):
+        subparser = subparsers.add_parser(
+            'set_replication_factor',
+            description='Increase/decrease the replication factor of a topic.',
+            help='This command is used to increase or decrease the replication'
+            ' factor of a topic. The brokers that the replicas are added to or'
+            ' removed from are chosen to maintain or increase the balance of'
+            ' the cluster.',
+        )
+        subparser.add_argument(
+            '--topic',
+            help='Kafka topic whose replication factor will be modified.',
+            required=True,
+        )
+        subparser.add_argument(
+            'replication_factor',
+            help='The new replication factor for the topic.',
+            type=self.positive_nonzero_int,
+        )
+        return subparser
+
+    def run_command(self, ct):
+        """Get executable proposed plan(if any) for display or execution."""
+        if self.args.topic in ct.topics:
+            topic = ct.topics[self.args.topic]
+        else:
+            self.log.error(
+                "Topic {topic} not found. Exiting."
+                .format(topic=self.args.topic),
+            )
+            sys.exit(1)
+
+        if topic.replication_factor == self.args.replication_factor:
+            self.log.info(
+                "Topic {topic} already has replication factor {rf}. "
+                "No action to perform."
+                .format(topic=topic.id, rf=self.args.replication_factor),
+            )
+            return
+
+        if self.args.replication_factor > len(ct.brokers):
+            self.log.error(
+                "Replication factor {rf} is greater than the total number of "
+                "brokers {brokers}. Exiting."
+                .format(
+                    rf=self.args.replication_factor,
+                    brokers=len(ct.brokers)
+                ),
+            )
+            sys.exit(1)
+
+        base_assignment = ct.assignment
+
+        if topic.replication_factor < self.args.replication_factor:
+            self.log.info(
+                "Increasing topic {topic} replication factor from {old_rf} to "
+                "{new_rf}."
+                .format(
+                    topic=topic.id,
+                    old_rf=topic.replication_factor,
+                    new_rf=self.args.replication_factor,
+                ),
+            )
+            for partition in topic.partitions:
+                ct.add_replica(
+                    partition,
+                    self.args.replication_factor - partition.replication_factor,
+                )
+        else:
+            self.log.info(
+                "Decreasing topic {topic} replication factor from {old_rf} to "
+                "{new_rf}."
+                .format(
+                    topic=topic.id,
+                    old_rf=topic.replication_factor,
+                    new_rf=self.args.replication_factor,
+                ),
+            )
+            for partition in topic.partitions:
+                ct.remove_replica(
+                    partition,
+                    partition.replication_factor - self.args.replication_factor,
+                )
+
+        assignment = ct.assignment
+
+        reduced_assignment = self.get_reduced_assignment(
+            base_assignment,
+            assignment,
+            max_partition_movements=1,
+            max_leader_only_changes=1,
+        )
+        self.process_assignment(reduced_assignment, allow_rf_change=True)

--- a/kafka_utils/kafka_cluster_manager/main.py
+++ b/kafka_utils/kafka_cluster_manager/main.py
@@ -32,6 +32,7 @@ from kafka_utils.kafka_cluster_manager.cluster_info.replication_group_parser \
 from kafka_utils.kafka_cluster_manager.cmds.decommission import DecommissionCmd
 from kafka_utils.kafka_cluster_manager.cmds.rebalance import RebalanceCmd
 from kafka_utils.kafka_cluster_manager.cmds.replace import ReplaceBrokerCmd
+from kafka_utils.kafka_cluster_manager.cmds.set_replication_factor import SetReplicationFactorCmd
 from kafka_utils.kafka_cluster_manager.cmds.stats import StatsCmd
 from kafka_utils.kafka_cluster_manager.cmds.store_assignments \
     import StoreAssignmentsCmd
@@ -125,6 +126,7 @@ def parse_args():
     StatsCmd().add_subparser(subparsers)
     StoreAssignmentsCmd().add_subparser(subparsers)
     ReplaceBrokerCmd().add_subparser(subparsers)
+    SetReplicationFactorCmd().add_subparser(subparsers)
 
     return parser.parse_args()
 

--- a/kafka_utils/util/zookeeper.py
+++ b/kafka_utils/util/zookeeper.py
@@ -424,13 +424,13 @@ class ZK:
         )
         self.delete(path, True)
 
-    def execute_plan(self, plan):
+    def execute_plan(self, plan, allow_rf_change=False):
         """Submit reassignment plan for execution."""
         reassignment_path = '{admin}/{reassignment_node}'\
             .format(admin=ADMIN_PATH, reassignment_node=REASSIGNMENT_NODE)
         plan_json = json.dumps(plan)
         base_plan = self.get_cluster_plan()
-        if not validate_plan(plan, base_plan):
+        if not validate_plan(plan, base_plan, allow_rf_change=allow_rf_change):
             _log.error('Given plan is invalid. ABORTING reassignment...')
             return False
         # Send proposed-plan to zookeeper

--- a/tests/kafka_cluster_manager/cluster_topology_test.py
+++ b/tests/kafka_cluster_manager/cluster_topology_test.py
@@ -998,8 +998,19 @@ class TestClusterTopology(object):
         assignment = dict([((u'T1', 0), ['0', '1', '2', '3', '5'])])
         ct = self.build_cluster_topology(assignment, self.srange(6))
         partition = ct.partitions[(u'T1', 0)]
+        osr = [ct.brokers['1'], ct.brokers['2']]
 
-        ct.remove_replica(partition, count=3)
+        ct.remove_replica(partition, osr, count=3)
 
         assert partition.replication_factor == 2
         assert sum(rg.count_replica(partition) for rg in ct.rgs.values()) == 2
+
+    def test_remove_replica_prioritize_osr(self):
+        assignment = dict([((u'T1', 0), ['0', '1', '2', '3', '5'])])
+        ct = self.build_cluster_topology(assignment, self.srange(6))
+        partition = ct.partitions[(u'T1', 0)]
+        osr = [ct.brokers['1'], ct.brokers['2']]
+
+        ct.remove_replica(partition, osr, count=2)
+
+        assert set(b.id for b in partition.replicas) == set(['0', '3', '5'])

--- a/tests/kafka_cluster_manager/cluster_topology_test.py
+++ b/tests/kafka_cluster_manager/cluster_topology_test.py
@@ -983,3 +983,23 @@ class TestClusterTopology(object):
 
         with pytest.raises(InvalidBrokerIdError):
             ct.replace_broker('0', '444')
+
+    def test_add_replica(self):
+        assignment = dict([((u'T1', 0), ['1', '3'])])
+        ct = self.build_cluster_topology(assignment, self.srange(6))
+        partition = ct.partitions[(u'T1', 0)]
+
+        ct.add_replica(ct.partitions[(u'T1', 0)], count=3)
+
+        assert partition.replication_factor == 5
+        assert sum(rg.count_replica(partition) for rg in ct.rgs.values()) == 5
+
+    def test_remove_replica(self):
+        assignment = dict([((u'T1', 0), ['0', '1', '2', '3', '5'])])
+        ct = self.build_cluster_topology(assignment, self.srange(6))
+        partition = ct.partitions[(u'T1', 0)]
+
+        ct.remove_replica(partition, count=3)
+
+        assert partition.replication_factor == 2
+        assert sum(rg.count_replica(partition) for rg in ct.rgs.values()) == 2

--- a/tests/kafka_cluster_manager/cmds/command_test.py
+++ b/tests/kafka_cluster_manager/cmds/command_test.py
@@ -12,9 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from argparse import ArgumentTypeError
 from collections import OrderedDict
 
 from pytest import fixture
+from pytest import raises
 
 from kafka_utils.kafka_cluster_manager.cmds.command import ClusterManagerCmd
 
@@ -49,6 +51,28 @@ def cmd():
 
 
 class TestClusterManagerCmd(object):
+
+    def test_positive_int_valid(self, cmd):
+        assert cmd.positive_int('123') == 123
+
+    def test_positive_int_not_int(self, cmd):
+        with raises(ArgumentTypeError):
+            cmd.positive_int('not_an_int')
+
+    def test_positive_int_negative_int(self, cmd):
+        with raises(ArgumentTypeError):
+            cmd.positive_int('-5')
+
+    def test_positive_nonzero_int_valid(self, cmd):
+        assert cmd.positive_nonzero_int('123') == 123
+
+    def test_positive_nonzero_int_not_int(self, cmd):
+        with raises(ArgumentTypeError):
+            cmd.positive_nonzero_int('not_an_int')
+
+    def test_positive_nonzero_int_zero(self, cmd):
+        with raises(ArgumentTypeError):
+            cmd.positive_nonzero_int('0')
 
     def test_reduced_proposed_plan_no_change(self, cmd, orig_assignment):
         # Provide same assignment

--- a/tests/kafka_cluster_manager/rg_test.py
+++ b/tests/kafka_cluster_manager/rg_test.py
@@ -642,3 +642,14 @@ class TestReplicationGroup(object):
         assert b1.partitions == set([p10])
         assert b2.partitions == set([p20])
         assert b3.partitions == set([p10, p20, p30])
+
+    def test_remove_replica_invalid_broker(self, create_partition):
+        p10 = create_partition('topic1', 0)
+        p20 = create_partition('topic2', 0)
+        b1 = create_broker('b1', [p10])
+        b2 = create_broker('b2', [p20])
+        b3 = create_broker('b3', [p10])
+        rg = ReplicationGroup('test_rg', set([b1, b2]))
+
+        with pytest.raises(AssertionError):
+            rg.remove_replica(p10, [b2, b3])

--- a/tests/kafka_cluster_manager/rg_test.py
+++ b/tests/kafka_cluster_manager/rg_test.py
@@ -615,3 +615,30 @@ class TestReplicationGroup(object):
             b1.topics == possible_topics2 and
             b2.topics == possible_topics1
         )
+
+    def test_add_replica(self, create_partition):
+        p10 = create_partition('topic1', 0)
+        p20 = create_partition('topic2', 0)
+        b1 = create_broker('b1', [p10, p20])
+        b2 = create_broker('b2', [p10, p20])
+        b3 = create_broker('b3', [p20])
+        rg = ReplicationGroup('test_rg', set([b1, b2, b3]))
+        rg.add_replica(p10)
+
+        assert b1.partitions == set([p10, p20])
+        assert b2.partitions == set([p10, p20])
+        assert b3.partitions == set([p10, p20])
+
+    def test_remove_replica(self, create_partition):
+        p10 = create_partition('topic1', 0)
+        p20 = create_partition('topic2', 0)
+        p30 = create_partition('topic3', 0)
+        b1 = create_broker('b1', [p10])
+        b2 = create_broker('b2', [p10, p20])
+        b3 = create_broker('b3', [p10, p20, p30])
+        rg = ReplicationGroup('test_rg', set([b1, b2, b3]))
+        rg.remove_replica(p10, [b1, b2])
+
+        assert b1.partitions == set([p10])
+        assert b2.partitions == set([p20])
+        assert b3.partitions == set([p10, p20, p30])

--- a/tests/util/validation_test.py
+++ b/tests/util/validation_test.py
@@ -353,6 +353,7 @@ def test_validate_plan_base_replication_factor_changed():
 
     # Verify validation failed
     assert _validate_plan_base(assignment, base_assignment) is False
+    assert _validate_plan_base(assignment, base_assignment, allow_rf_change=True)
 
 
 def test_validate_plan_1():

--- a/tests/util/validation_test.py
+++ b/tests/util/validation_test.py
@@ -372,7 +372,7 @@ def test_validate_plan_base_replication_factor_changed_allowed():
         ]
     }
 
-    # Verify validation failed
+    # Verify validation passed
     assert _validate_plan_base(assignment, base_assignment, allow_rf_change=True)
 
 

--- a/tests/util/validation_test.py
+++ b/tests/util/validation_test.py
@@ -353,6 +353,26 @@ def test_validate_plan_base_replication_factor_changed():
 
     # Verify validation failed
     assert _validate_plan_base(assignment, base_assignment) is False
+
+
+def test_validate_plan_base_replication_factor_changed_allowed():
+    # replication-factor of (t1, 0) is 1 in assignment and 2 in base-assignment
+    assignment = {
+        "version": 1,
+        "partitions": [
+            {"partition": 0, "topic": u't1', "replicas": [1]},
+            {"partition": 0, "topic": u't2', "replicas": [0, 1]}
+        ]
+    }
+    base_assignment = {
+        "version": 1,
+        "partitions": [
+            {"partition": 0, "topic": u't1', "replicas": [0, 2]},
+            {"partition": 0, "topic": u't2', "replicas": [0, 1]}
+        ]
+    }
+
+    # Verify validation failed
     assert _validate_plan_base(assignment, base_assignment, allow_rf_change=True)
 
 


### PR DESCRIPTION
`usage: kafka-cluster-manager set_replication_factor [-h] --topic TOPIC replication_factor`

This command increases or decreases the replication factor of all partitions of a topic. It tries to do so in a way that spreads replicas across replication-groups and maintains the overall balance of the cluster.