### PR TITLE
offset_get ignores --storage option when checking group existence

### DIFF
--- a/kafka_utils/kafka_consumer_manager/commands/list_groups.py
+++ b/kafka_utils/kafka_consumer_manager/commands/list_groups.py
@@ -15,25 +15,13 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import logging
 import sys
-from collections import defaultdict
 
-from kafka.common import ConsumerTimeout
-from kafka.common import FailedPayloadsError
-from kafka.common import KafkaUnavailableError
-from kafka.common import LeaderNotAvailableError
-from kafka.common import NotLeaderForPartitionError
-from kafka.consumer import KafkaConsumer
-from kafka.util import read_short_string
-from kafka.util import relative_unpack
 from kazoo.exceptions import NoNodeError
 
 from .offset_manager import OffsetManagerBase
-from kafka_utils.util.offsets import get_topics_watermarks
+from kafka_utils.kafka_consumer_manager.util import KafkaGroupReader
 from kafka_utils.util.zookeeper import ZK
-
-CONSUMER_OFFSET_TOPIC = '__consumer_offsets'
 
 
 class ListGroups(OffsetManagerBase):
@@ -106,91 +94,3 @@ class ListGroups(OffsetManagerBase):
                 groups.update(kafka_groups)
 
         cls.print_groups(groups, cluster_config)
-
-
-class InvalidMessageException(Exception):
-    pass
-
-
-class KafkaGroupReader:
-
-    def __init__(self, kafka_config):
-        self.log = logging.getLogger(__name__)
-        self.kafka_config = kafka_config
-        self.kafka_groups = defaultdict(set)
-        self.finished_partitions = set()
-
-    def read_groups(self):
-        self.log.info("Kafka consumer running")
-        self.consumer = KafkaConsumer(
-            CONSUMER_OFFSET_TOPIC,
-            group_id='offset_monitoring_consumer',
-            bootstrap_servers=self.kafka_config.broker_list,
-            auto_offset_reset='smallest',
-            auto_commit_enable=False,
-            consumer_timeout_ms=10000,
-        )
-        self.log.info("Consumer ready")
-        self.watermarks = self.get_current_watermarks()
-        while not self.finished():
-            try:
-                message = self.consumer.next()
-                max_offset = self.get_max_offset(message.partition)
-                if message.offset >= max_offset - 1:
-                    self.finished_partitions.add(message.partition)
-            except ConsumerTimeout:
-                break
-            except (
-                    FailedPayloadsError,
-                    KafkaUnavailableError,
-                    LeaderNotAvailableError,
-                    NotLeaderForPartitionError,
-            ) as e:
-                self.log.warning("Got %s, retrying", e.__class__.__name__)
-            self.process_consumer_offset_message(message)
-        return self.kafka_groups
-
-    def parse_consumer_offset_message(self, message):
-        key = bytearray(message.key)
-        ((key_schema,), cur) = relative_unpack('>h', key, 0)
-        if key_schema not in [0, 1]:
-            raise InvalidMessageException()   # This is not an offset commit message
-        (group, cur) = read_short_string(key, cur)
-        (topic, cur) = read_short_string(key, cur)
-        ((partition,), cur) = relative_unpack('>l', key, cur)
-        if message.value:
-            value = bytearray(message.value)
-            ((value_schema,), cur) = relative_unpack('>h', value, 0)
-            if value_schema not in [0, 1]:
-                raise InvalidMessageException()  # Unrecognized message value
-            ((offset,), cur) = relative_unpack('>q', value, cur)
-        else:
-            offset = None  # Offset was deleted
-        return str(group), str(topic), partition, offset
-
-    def process_consumer_offset_message(self, message):
-        try:
-            group, topic, partition, offset = self.parse_consumer_offset_message(message)
-        except InvalidMessageException:
-            return
-
-        if offset:
-            self.kafka_groups[group].add(topic)
-        else:  # No offset means group deletion
-            self.kafka_groups.pop(group, None)
-
-    def get_current_watermarks(self):
-        self.consumer._client.load_metadata_for_topics()
-        offsets = get_topics_watermarks(
-            self.consumer._client,
-            [CONSUMER_OFFSET_TOPIC],
-        )
-        return {partition: offset for partition, offset
-                in offsets[CONSUMER_OFFSET_TOPIC].iteritems()
-                if offset.highmark > offset.lowmark}
-
-    def get_max_offset(self, partition):
-        return self.watermarks[partition].highmark
-
-    def finished(self):
-        return len(self.finished_partitions) >= len(self.watermarks)

--- a/kafka_utils/kafka_consumer_manager/commands/list_topics.py
+++ b/kafka_utils/kafka_consumer_manager/commands/list_topics.py
@@ -46,9 +46,12 @@ class ListTopics(OffsetManagerBase):
         client.load_metadata_for_topics()
 
         topics_dict = cls.preprocess_args(
-            args.groupid, None, None,
-            cluster_config, client,
-            False
+            groupid=args.groupid,
+            topic=None,
+            partitions=None,
+            cluster_config=cluster_config,
+            client=client,
+            fail_on_error=False,
         )
         if not topics_dict:
             print(

--- a/kafka_utils/kafka_consumer_manager/commands/offset_get.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_get.py
@@ -88,7 +88,8 @@ class OffsetGet(OffsetManagerBase):
             partitions=args.partitions,
             cluster_config=cluster_config,
             client=client,
-            quiet=args.json
+            quiet=args.json,
+            storage=args.storage,
         )
 
         consumer_offsets_metadata = cls.get_offsets(

--- a/kafka_utils/kafka_consumer_manager/commands/offset_get.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_get.py
@@ -83,7 +83,11 @@ class OffsetGet(OffsetManagerBase):
         client.load_metadata_for_topics()
 
         topics_dict = cls.preprocess_args(
-            args.groupid, args.topic, args.partitions, cluster_config, client,
+            groupid=args.groupid,
+            topic=args.topic,
+            partitions=args.partitions,
+            cluster_config=cluster_config,
+            client=client,
             quiet=args.json
         )
 

--- a/kafka_utils/kafka_consumer_manager/commands/offset_manager.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_manager.py
@@ -32,25 +32,12 @@ class OffsetManagerBase(object):
         cls,
         cluster_config,
         groupid,
+        storage='zookeeper',
         fail_on_error=True,
     ):
-        topics = []
-        with ZK(cluster_config) as zk:
-            # Query zookeeper to get the list of topics that this consumer is
-            # subscribed to.
-            try:
-                topics = zk.get_my_subscribed_topics(groupid)
-            except NoNodeError:
-                if fail_on_error:
-                    print(
-                        "Error: Consumer Group ID {groupid} does not exist.".format(
-                            groupid=groupid
-                        ),
-                        file=sys.stderr
-                    )
-                    sys.exit(1)
-
-        return topics
+        if storage == 'kafka':
+            return cls.get_topics_for_group_from_kafka(cluster_config, groupid)
+        return cls.get_topics_for_group_from_zookeeper(cluster_config, groupid, fail_on_error)
 
     @classmethod
     def preprocess_args(
@@ -79,15 +66,12 @@ class OffsetManagerBase(object):
                     groupid=groupid,
                 ),
             )
-        if storage == 'zookeeper':
-            topics = cls.get_topics_from_consumer_group_id(
-                cluster_config,
-                groupid,
-                fail_on_error,
-            )
-        else:
-            kafka_group_reader = KafkaGroupReader(cluster_config)
-            topics = kafka_group_reader.read_groups().get(groupid, [])
+        topics = cls.get_topics_from_consumer_group_id(
+            cluster_config,
+            groupid,
+            storage,
+            fail_on_error,
+        )
         topics_dict = {}
         if topic:
             if topic not in topics:
@@ -139,6 +123,39 @@ class OffsetManagerBase(object):
     def add_parser(cls, subparsers):
         cls.setup_subparser(subparsers)
 
+    @classmethod
+    def get_topics_for_group_from_kafka(
+            cls,
+            cluster_config,
+            groupid
+    ):
+        kafka_group_reader = KafkaGroupReader(cluster_config)
+        return kafka_group_reader.read_groups().get(groupid, [])
+
+    @classmethod
+    def get_topics_for_group_from_zookeeper(
+            cls,
+            cluster_config,
+            groupid,
+            fail_on_error
+    ):
+        topics = []
+        with ZK(cluster_config) as zk:
+            # Query zookeeper to get the list of topics that this consumer is
+            # subscribed to.
+            try:
+                topics = zk.get_my_subscribed_topics(groupid)
+            except NoNodeError:
+                if fail_on_error:
+                    print(
+                        "Error: Consumer Group ID {groupid} does not exist.".format(
+                            groupid=groupid
+                        ),
+                        file=sys.stderr
+                    )
+                    sys.exit(1)
+        return topics
+
 
 class OffsetWriter(OffsetManagerBase):
 
@@ -150,6 +167,7 @@ class OffsetWriter(OffsetManagerBase):
         partitions,
         cluster_config,
         client,
+        storage='zookeeper',
         fail_on_error=True,
         force=False,
     ):

--- a/kafka_utils/kafka_consumer_manager/commands/offset_manager.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_manager.py
@@ -20,6 +20,7 @@ import sys
 
 from kazoo.exceptions import NoNodeError
 
+from kafka_utils.kafka_consumer_manager.util import KafkaGroupReader
 from kafka_utils.kafka_consumer_manager.util import prompt_user_input
 from kafka_utils.util.zookeeper import ZK
 
@@ -59,6 +60,7 @@ class OffsetManagerBase(object):
         partitions,
         cluster_config,
         client,
+        storage='zookeeper',
         fail_on_error=True,
         quiet=False
     ):
@@ -77,11 +79,15 @@ class OffsetManagerBase(object):
                     groupid=groupid,
                 ),
             )
-        topics = cls.get_topics_from_consumer_group_id(
-            cluster_config,
-            groupid,
-            fail_on_error,
-        )
+        if storage == 'zookeeper':
+            topics = cls.get_topics_from_consumer_group_id(
+                cluster_config,
+                groupid,
+                fail_on_error,
+            )
+        else:
+            kafka_group_reader = KafkaGroupReader(cluster_config)
+            topics = kafka_group_reader.read_groups().get(groupid, [])
         topics_dict = {}
         if topic:
             if topic not in topics:

--- a/kafka_utils/kafka_consumer_manager/commands/offset_save.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_save.py
@@ -80,11 +80,11 @@ class OffsetSave(OffsetManagerBase):
         client.load_metadata_for_topics()
 
         topics_dict = cls.preprocess_args(
-            args.groupid,
-            args.topic,
-            args.partitions,
-            cluster_config,
-            client,
+            groupid=args.groupid,
+            topic=args.topic,
+            partitions=args.partitions,
+            cluster_config=cluster_config,
+            client=client,
         )
         try:
             consumer_offsets_metadata = get_consumer_offsets_metadata(

--- a/kafka_utils/kafka_consumer_manager/commands/rename_group.py
+++ b/kafka_utils/kafka_consumer_manager/commands/rename_group.py
@@ -65,7 +65,11 @@ class RenameGroup(OffsetManagerBase):
         client.load_metadata_for_topics()
 
         topics_dict = cls.preprocess_args(
-            args.old_groupid, None, None, cluster_config, client
+            groupid=args.old_groupid,
+            topic=None,
+            partitions=None,
+            cluster_config=cluster_config,
+            client=client,
         )
         with ZK(cluster_config) as zk:
             try:

--- a/kafka_utils/kafka_consumer_manager/util.py
+++ b/kafka_utils/kafka_consumer_manager/util.py
@@ -158,6 +158,7 @@ class KafkaGroupReader:
                 max_offset = self.get_max_offset(message.partition)
                 if message.offset >= max_offset - 1:
                     self.finished_partitions.add(message.partition)
+                self.process_consumer_offset_message(message)
             except ConsumerTimeout:
                 break
             except (
@@ -167,7 +168,6 @@ class KafkaGroupReader:
                     NotLeaderForPartitionError,
             ) as e:
                 self.log.warning("Got %s, retrying", e.__class__.__name__)
-            self.process_consumer_offset_message(message)
         return self.kafka_groups
 
     def parse_consumer_offset_message(self, message):

--- a/kafka_utils/kafka_consumer_manager/util.py
+++ b/kafka_utils/kafka_consumer_manager/util.py
@@ -16,10 +16,23 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import logging
 import sys
 from collections import defaultdict
 
+from kafka.common import ConsumerTimeout
+from kafka.common import FailedPayloadsError
+from kafka.common import KafkaUnavailableError
+from kafka.common import LeaderNotAvailableError
+from kafka.common import NotLeaderForPartitionError
+from kafka.consumer import KafkaConsumer
+from kafka.util import read_short_string
+from kafka.util import relative_unpack
 from kazoo.exceptions import NodeExistsError
+
+from kafka_utils.util.offsets import get_topics_watermarks
+
+CONSUMER_OFFSET_TOPIC = '__consumer_offsets'
 
 
 def preprocess_topics(source_groupid, source_topics, dest_groupid, topics_dest_group):
@@ -113,3 +126,91 @@ def prompt_user_input(in_str):
             sys.exit(0)
         if answer == "y" or answer == "yes":
             return
+
+
+class InvalidMessageException(Exception):
+    pass
+
+
+class KafkaGroupReader:
+
+    def __init__(self, kafka_config):
+        self.log = logging.getLogger(__name__)
+        self.kafka_config = kafka_config
+        self.kafka_groups = defaultdict(set)
+        self.finished_partitions = set()
+
+    def read_groups(self):
+        self.log.info("Kafka consumer running")
+        self.consumer = KafkaConsumer(
+            CONSUMER_OFFSET_TOPIC,
+            group_id='offset_monitoring_consumer',
+            bootstrap_servers=self.kafka_config.broker_list,
+            auto_offset_reset='smallest',
+            auto_commit_enable=False,
+            consumer_timeout_ms=10000,
+        )
+        self.log.info("Consumer ready")
+        self.watermarks = self.get_current_watermarks()
+        while not self.finished():
+            try:
+                message = self.consumer.next()
+                max_offset = self.get_max_offset(message.partition)
+                if message.offset >= max_offset - 1:
+                    self.finished_partitions.add(message.partition)
+            except ConsumerTimeout:
+                break
+            except (
+                    FailedPayloadsError,
+                    KafkaUnavailableError,
+                    LeaderNotAvailableError,
+                    NotLeaderForPartitionError,
+            ) as e:
+                self.log.warning("Got %s, retrying", e.__class__.__name__)
+            self.process_consumer_offset_message(message)
+        return self.kafka_groups
+
+    def parse_consumer_offset_message(self, message):
+        key = bytearray(message.key)
+        ((key_schema,), cur) = relative_unpack('>h', key, 0)
+        if key_schema not in [0, 1]:
+            raise InvalidMessageException()   # This is not an offset commit message
+        (group, cur) = read_short_string(key, cur)
+        (topic, cur) = read_short_string(key, cur)
+        ((partition,), cur) = relative_unpack('>l', key, cur)
+        if message.value:
+            value = bytearray(message.value)
+            ((value_schema,), cur) = relative_unpack('>h', value, 0)
+            if value_schema not in [0, 1]:
+                raise InvalidMessageException()  # Unrecognized message value
+            ((offset,), cur) = relative_unpack('>q', value, cur)
+        else:
+            offset = None  # Offset was deleted
+        return str(group), str(topic), partition, offset
+
+    def process_consumer_offset_message(self, message):
+        try:
+            group, topic, partition, offset = self.parse_consumer_offset_message(message)
+        except InvalidMessageException:
+            return
+
+        if offset:
+            self.kafka_groups[group].add(topic)
+        else:  # No offset means group deletion
+            self.kafka_groups.pop(group, None)
+
+    def get_current_watermarks(self):
+        self.consumer._client.load_metadata_for_topics()
+        offsets = get_topics_watermarks(
+            self.consumer._client,
+            [CONSUMER_OFFSET_TOPIC],
+        )
+        return {partition: offset for partition, offset
+                in offsets[CONSUMER_OFFSET_TOPIC].iteritems()
+                if offset.highmark > offset.lowmark}
+
+    def get_max_offset(self, partition):
+        return self.watermarks[partition].highmark
+
+    def finished(self):
+        return len(self.finished_partitions) >= len(self.watermarks)

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ pycparser==2.10
 pycrypto==2.6.1
 requests==2.7.0
 requests-futures==0.9.5
+retrying==1.3.3
 setproctitle==1.1.8
 simplejson==3.6.5
 six==1.9.0

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         "requests-futures>0.9.0",
         "kafka-python<1.0.0",
         "requests<3.0.0",
+        'retrying'
     ],
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/tests/kafka_consumer_manager/test_utils.py
+++ b/tests/kafka_consumer_manager/test_utils.py
@@ -41,7 +41,7 @@ class TestKafkaGroupReader(object):
         struct.pack('>q', 123),  # Offset 123
     ])
 
-    def test__parse_consumer_offset_message_correct(self):
+    def test_parse_consumer_offset_message_correct(self):
         kafka_config = mock.Mock()
         kafka_group_reader = KafkaGroupReader(kafka_config)
         message = Message(0, '__consumer_offsets', self.key_ok, self.value_ok)
@@ -52,7 +52,7 @@ class TestKafkaGroupReader(object):
         assert partition == 15
         assert offset == 123
 
-    def test__parse_consumer_offset_message_no_value(self):
+    def test_parse_consumer_offset_message_no_value(self):
         kafka_config = mock.Mock()
         kafka_group_reader = KafkaGroupReader(kafka_config)
         message = Message(0, '__consumer_offsets', self.key_ok, None)
@@ -64,7 +64,7 @@ class TestKafkaGroupReader(object):
         assert offset is None
 
     @mock.patch.object(KafkaGroupReader, 'parse_consumer_offset_message')
-    def test__process_consumer_offset_message_grous(self, parse_mock):
+    def test_process_consumer_offset_message_grous(self, parse_mock):
         parse_mock.side_effect = [('test.a', 'topic1', 0, 123),
                                   ('test.a', 'topic1', 1, 124),
                                   ('test.a', 'topic2', 0, 125),
@@ -81,7 +81,7 @@ class TestKafkaGroupReader(object):
         assert kafka_group_reader.kafka_groups == expected
 
     @mock.patch.object(KafkaGroupReader, 'parse_consumer_offset_message')
-    def test__process_consumer_offset_message_invalid_message(self, parse_mock):
+    def test_process_consumer_offset_message_invalid_message(self, parse_mock):
         parse_mock.side_effect = InvalidMessageException
         kafka_group_reader = KafkaGroupReader(mock.Mock())
         message = mock.MagicMock(spec=KafkaMessage)
@@ -117,15 +117,15 @@ class TestKafkaGroupReader(object):
         assert kafka_group_reader.kafka_groups['test_group'] == {'test_topic'}
 
         with mock.patch.object(
-                kafka_group_reader,
-                'parse_consumer_offset_message',
-                return_value=[
-                    'test_group',
-                    'test_topic',
-                    0,
-                    None
-                ],
-                autospec=True
+            kafka_group_reader,
+            'parse_consumer_offset_message',
+            return_value=[
+                'test_group',
+                'test_topic',
+                0,
+                None
+            ],
+            autospec=True
         ):
             kafka_group_reader.process_consumer_offset_message('test message')
             assert kafka_group_reader.kafka_groups == {}
@@ -141,12 +141,13 @@ class TestKafkaGroupReader(object):
             with mock.patch.object(
                 kafka_group_reader,
                 'get_current_watermarks',
-                return_value={0: PartitionOffsets(
+                return_value={
+                    0: PartitionOffsets(
                     'test_topic',
                     0,
                     45,
                     0
-                )
+                    )
                 },
                 autospec=True
             ):
@@ -177,12 +178,13 @@ class TestKafkaGroupReader(object):
             with mock.patch.object(
                 kafka_group_reader,
                 'get_current_watermarks',
-                return_value={0: PartitionOffsets(
+                return_value={
+                    0: PartitionOffsets(
                     'test_topic',
                     0,
                     45,
                     0
-                )
+                    )
                 },
                 autospec=True
             ):
@@ -207,15 +209,16 @@ class TestKafkaGroupReader(object):
                 autospec=True
         ) as mock_consumer:
             with mock.patch.object(
-                    kafka_group_reader,
-                    'get_current_watermarks',
-                    return_value={0: PartitionOffsets(
+                kafka_group_reader,
+                'get_current_watermarks',
+                return_value={
+                    0: PartitionOffsets(
                         'test_topic',
                         0,
                         45,
                         0
                     )
-                    },
+                },
                     autospec=True
             ):
                 with mock.patch.object(
@@ -234,15 +237,16 @@ class TestKafkaGroupReader(object):
         kafka_config = mock.Mock()
         kafka_group_reader = KafkaGroupReader(kafka_config)
         with mock.patch.object(
-                kafka_group_reader,
-                'get_current_watermarks',
-                return_value={0: PartitionOffsets(
-                    'test_topic',
-                    0,
-                    45,
-                    0
+            kafka_group_reader,
+            'get_current_watermarks',
+            return_value={
+                0: PartitionOffsets(
+                'test_topic',
+                0,
+                45,
+                0
                 )
-                },
+            },
                 autospec=True
         ) as mock_get_watermarks:
             kafka_group_reader.watermarks = mock_get_watermarks()

--- a/tests/kafka_consumer_manager/test_utils.py
+++ b/tests/kafka_consumer_manager/test_utils.py
@@ -1,0 +1,41 @@
+import mock
+
+from kafka_utils.kafka_consumer_manager.util import KafkaGroupReader
+
+
+class TestUtils(object):
+
+    def test_process_consumer_offset_message_topic_get(self):
+        kafka_config = mock.Mock()
+        kafka_group_reader = KafkaGroupReader(kafka_config)
+
+        assert kafka_group_reader.kafka_groups == {}
+
+        with mock.patch.object(kafka_group_reader,
+                               'parse_consumer_offset_message',
+                               return_value=['test_group',
+                                             'test_topic',
+                                             0,
+                                             45
+                                             ]
+                               ):
+            kafka_group_reader.process_consumer_offset_message('test message')
+            assert kafka_group_reader.kafka_groups['test_group'] == {'test_topic'}
+
+    def test_process_consumer_offset_message_topic_pop_no_offset(self):
+        kafka_config = mock.Mock()
+        kafka_group_reader = KafkaGroupReader(kafka_config)
+
+        kafka_group_reader.kafka_groups['test_group'] = {'test_topic'}
+        assert kafka_group_reader.kafka_groups['test_group'] == {'test_topic'}
+
+        with mock.patch.object(kafka_group_reader,
+                               'parse_consumer_offset_message',
+                               return_value=['test_group',
+                                             'test_topic',
+                                             0,
+                                             None
+                                             ]
+                               ):
+            kafka_group_reader.process_consumer_offset_message('test message')
+            assert kafka_group_reader.kafka_groups == {}

--- a/tests/kafka_consumer_manager/test_utils.py
+++ b/tests/kafka_consumer_manager/test_utils.py
@@ -1,11 +1,93 @@
+import struct
+from collections import namedtuple
+
 import mock
 from kafka.common import ConsumerTimeout
+from kafka.common import KafkaMessage
+from kafka.common import LeaderNotAvailableError
 
+from kafka_utils.kafka_consumer_manager.util import InvalidMessageException
 from kafka_utils.kafka_consumer_manager.util import KafkaGroupReader
 from kafka_utils.util.offsets import PartitionOffsets
 
+Message = namedtuple("Message", ["partition", "offset", "key", "value"])
 
-class TestUtils(object):
+
+class TestKafkaGroupReader(object):
+
+    groups = ['^test\..*', '^my_test$', '^my_test2$']
+
+    key_ok = b''.join([
+        struct.pack('>h', 0),  # Schema: offset commit
+        struct.pack('>h6s', 6, b'group1'),  # Group name
+        struct.pack('>h6s', 6, b'topic1'),  # Topic name
+        struct.pack('>l', 15),  # Partition
+    ])
+
+    value_ok = b''.join([
+        struct.pack('>h', 0),  # Schema: version 0
+        struct.pack('>q', 123),  # Offset 123
+    ])
+
+    key_wrong = b''.join([
+        struct.pack('>h', 2),  # Schema: group message
+        struct.pack('>h6s', 6, b'group1'),  # Group name
+        struct.pack('>h6s', 6, b'topic1'),  # Topic name
+        struct.pack('>l', 15),  # Partition
+    ])
+
+    value_wrong = b''.join([
+        struct.pack('>h', 3),  # Schema: invalid
+        struct.pack('>q', 123),  # Offset 123
+    ])
+
+    def test__parse_consumer_offset_message_correct(self):
+        kafka_config = mock.Mock()
+        kafka_group_reader = KafkaGroupReader(kafka_config)
+        message = Message(0, '__consumer_offsets', self.key_ok, self.value_ok)
+        group, topic, partition, offset = kafka_group_reader.parse_consumer_offset_message(message)
+
+        assert group == 'group1'
+        assert topic == 'topic1'
+        assert partition == 15
+        assert offset == 123
+
+    def test__parse_consumer_offset_message_no_value(self):
+        kafka_config = mock.Mock()
+        kafka_group_reader = KafkaGroupReader(kafka_config)
+        message = Message(0, '__consumer_offsets', self.key_ok, None)
+        group, topic, partition, offset = kafka_group_reader.parse_consumer_offset_message(message)
+
+        assert group == 'group1'
+        assert topic == 'topic1'
+        assert partition == 15
+        assert offset is None
+
+    @mock.patch.object(KafkaGroupReader, 'parse_consumer_offset_message')
+    def test__process_consumer_offset_message_grous(self, parse_mock):
+        parse_mock.side_effect = [('test.a', 'topic1', 0, 123),
+                                  ('test.a', 'topic1', 1, 124),
+                                  ('test.a', 'topic2', 0, 125),
+                                  ('my_test', 'topic1', 0, 123),
+                                  ('my_test', 'topic2', 0, 124),
+                                  ('my_test', 'topic2', 0, None),
+                                  ('my_test2', 'topic3', 0, 123), ]
+        kafka_group_reader = KafkaGroupReader(mock.Mock())
+        for _ in range(7):
+            message = mock.MagicMock(spec=KafkaMessage)
+            kafka_group_reader.process_consumer_offset_message(message)
+
+        expected = {'test.a': {'topic1', 'topic2'}, 'my_test2': {'topic3'}}
+        assert kafka_group_reader.kafka_groups == expected
+
+    @mock.patch.object(KafkaGroupReader, 'parse_consumer_offset_message')
+    def test__process_consumer_offset_message_invalid_message(self, parse_mock):
+        parse_mock.side_effect = InvalidMessageException
+        kafka_group_reader = KafkaGroupReader(mock.Mock())
+        message = mock.MagicMock(spec=KafkaMessage)
+        kafka_group_reader.process_consumer_offset_message(message)
+
+        assert kafka_group_reader.kafka_groups == dict()
 
     def test_process_consumer_offset_message_topic_get(self):
         kafka_config = mock.Mock()
@@ -21,7 +103,8 @@ class TestUtils(object):
                 'test_topic',
                 0,
                 45
-            ]
+            ],
+            autospec=True
         ):
             kafka_group_reader.process_consumer_offset_message('test message')
             assert kafka_group_reader.kafka_groups['test_group'] == {'test_topic'}
@@ -41,25 +124,20 @@ class TestUtils(object):
                     'test_topic',
                     0,
                     None
-                ]
+                ],
+                autospec=True
         ):
             kafka_group_reader.process_consumer_offset_message('test message')
             assert kafka_group_reader.kafka_groups == {}
 
     def test_read_groups(self):
 
-        class Mock_Consumer(object):
-
-            def next(self):
-                return message
-
         kafka_config = mock.Mock()
         kafka_group_reader = KafkaGroupReader(kafka_config)
-        message = mock.Mock(partition=0, topic='test_topic')
         with mock.patch(
                 'kafka_utils.kafka_consumer_manager.util.KafkaConsumer',
-                return_value=Mock_Consumer()
-        ):
+                autospec=True
+        ) as mock_consumer:
             with mock.patch.object(
                 kafka_group_reader,
                 'get_current_watermarks',
@@ -69,7 +147,8 @@ class TestUtils(object):
                     45,
                     0
                 )
-                }
+                },
+                autospec=True
             ):
                 with mock.patch.object(
                     kafka_group_reader,
@@ -79,25 +158,22 @@ class TestUtils(object):
                         'test_topic',
                         0,
                         45
-                    ]
+                    ],
+                    autospec=True
                 ):
+                    mock_consumer.return_value.next.return_value = mock.Mock(partition=0, topic='test_topic')
                     kafka_group_reader.read_groups()
                     assert kafka_group_reader.kafka_groups['test_group'] == {"test_topic"}
                     assert len(kafka_group_reader.finished_partitions) == 1
 
     def test_read_groups_with_consumer_timeout(self):
 
-        class Mock_Consumer(object):
-
-            def next(self):
-                raise ConsumerTimeout
-
         kafka_config = mock.Mock()
         kafka_group_reader = KafkaGroupReader(kafka_config)
         with mock.patch(
                 'kafka_utils.kafka_consumer_manager.util.KafkaConsumer',
-                return_value=Mock_Consumer()
-        ):
+                autospec=True
+        ) as mock_consumer:
             with mock.patch.object(
                 kafka_group_reader,
                 'get_current_watermarks',
@@ -107,30 +183,67 @@ class TestUtils(object):
                     45,
                     0
                 )
-                }
+                },
+                autospec=True
             ):
                 with mock.patch.object(
                     kafka_group_reader,
                     'process_consumer_offset_message',
+                    autospec=True
                 ) as mock_process_consumer_offset_message:
+                    mock_consumer.return_value.next.side_effect = ConsumerTimeout
                     kafka_group_reader.read_groups()
                     assert kafka_group_reader.kafka_groups == {}
                     assert mock_process_consumer_offset_message.call_count == 0
                     assert len(kafka_group_reader.finished_partitions) == 0
+                    assert kafka_group_reader.retry != kafka_group_reader.retry_max
+                    assert kafka_group_reader.retry == 0
+
+    def test_read_groups_with_leader_not_available_error(self):
+        kafka_config = mock.Mock()
+        kafka_group_reader = KafkaGroupReader(kafka_config)
+        with mock.patch(
+                'kafka_utils.kafka_consumer_manager.util.KafkaConsumer',
+                autospec=True
+        ) as mock_consumer:
+            with mock.patch.object(
+                    kafka_group_reader,
+                    'get_current_watermarks',
+                    return_value={0: PartitionOffsets(
+                        'test_topic',
+                        0,
+                        45,
+                        0
+                    )
+                    },
+                    autospec=True
+            ):
+                with mock.patch.object(
+                        kafka_group_reader,
+                        'process_consumer_offset_message',
+                        autospec=True
+                ) as mock_process_consumer_offset_message:
+                    mock_consumer.return_value.next.side_effect = LeaderNotAvailableError
+                    kafka_group_reader.read_groups()
+                    assert kafka_group_reader.kafka_groups == {}
+                    assert mock_process_consumer_offset_message.call_count == 0
+                    assert len(kafka_group_reader.finished_partitions) == 0
+                    assert kafka_group_reader.retry == kafka_group_reader.retry_max + 1
 
     def test_get_max_offset(self):
         kafka_config = mock.Mock()
         kafka_group_reader = KafkaGroupReader(kafka_config)
         with mock.patch.object(
-            kafka_group_reader,
-            'get_current_watermarks',
-            return_value={0: PartitionOffsets(
-                'test_topic',
-                0,
-                45,
-                0
-            )
-            }
+                kafka_group_reader,
+                'get_current_watermarks',
+                return_value={0: PartitionOffsets(
+                    'test_topic',
+                    0,
+                    45,
+                    0
+                )
+                },
+                autospec=True
         ) as mock_get_watermarks:
             kafka_group_reader.watermarks = mock_get_watermarks()
             highmark = kafka_group_reader.get_max_offset(0)

--- a/tests/kafka_consumer_manager/test_utils.py
+++ b/tests/kafka_consumer_manager/test_utils.py
@@ -1,6 +1,8 @@
 import mock
+from kafka.common import ConsumerTimeout
 
 from kafka_utils.kafka_consumer_manager.util import KafkaGroupReader
+from kafka_utils.util.offsets import PartitionOffsets
 
 
 class TestUtils(object):
@@ -11,14 +13,16 @@ class TestUtils(object):
 
         assert kafka_group_reader.kafka_groups == {}
 
-        with mock.patch.object(kafka_group_reader,
-                               'parse_consumer_offset_message',
-                               return_value=['test_group',
-                                             'test_topic',
-                                             0,
-                                             45
-                                             ]
-                               ):
+        with mock.patch.object(
+            kafka_group_reader,
+            'parse_consumer_offset_message',
+            return_value=[
+                'test_group',
+                'test_topic',
+                0,
+                45
+            ]
+        ):
             kafka_group_reader.process_consumer_offset_message('test message')
             assert kafka_group_reader.kafka_groups['test_group'] == {'test_topic'}
 
@@ -29,13 +33,105 @@ class TestUtils(object):
         kafka_group_reader.kafka_groups['test_group'] = {'test_topic'}
         assert kafka_group_reader.kafka_groups['test_group'] == {'test_topic'}
 
-        with mock.patch.object(kafka_group_reader,
-                               'parse_consumer_offset_message',
-                               return_value=['test_group',
-                                             'test_topic',
-                                             0,
-                                             None
-                                             ]
-                               ):
+        with mock.patch.object(
+                kafka_group_reader,
+                'parse_consumer_offset_message',
+                return_value=[
+                    'test_group',
+                    'test_topic',
+                    0,
+                    None
+                ]
+        ):
             kafka_group_reader.process_consumer_offset_message('test message')
             assert kafka_group_reader.kafka_groups == {}
+
+    def test_read_groups(self):
+
+        class Mock_Consumer(object):
+
+            def next(self):
+                return message
+
+        kafka_config = mock.Mock()
+        kafka_group_reader = KafkaGroupReader(kafka_config)
+        message = mock.Mock(partition=0, topic='test_topic')
+        with mock.patch(
+                'kafka_utils.kafka_consumer_manager.util.KafkaConsumer',
+                return_value=Mock_Consumer()
+        ):
+            with mock.patch.object(
+                kafka_group_reader,
+                'get_current_watermarks',
+                return_value={0: PartitionOffsets(
+                    'test_topic',
+                    0,
+                    45,
+                    0
+                )
+                }
+            ):
+                with mock.patch.object(
+                    kafka_group_reader,
+                    'parse_consumer_offset_message',
+                    return_value=[
+                        'test_group',
+                        'test_topic',
+                        0,
+                        45
+                    ]
+                ):
+                    kafka_group_reader.read_groups()
+                    assert kafka_group_reader.kafka_groups['test_group'] == {"test_topic"}
+                    assert len(kafka_group_reader.finished_partitions) == 1
+
+    def test_read_groups_with_consumer_timeout(self):
+
+        class Mock_Consumer(object):
+
+            def next(self):
+                raise ConsumerTimeout
+
+        kafka_config = mock.Mock()
+        kafka_group_reader = KafkaGroupReader(kafka_config)
+        with mock.patch(
+                'kafka_utils.kafka_consumer_manager.util.KafkaConsumer',
+                return_value=Mock_Consumer()
+        ):
+            with mock.patch.object(
+                kafka_group_reader,
+                'get_current_watermarks',
+                return_value={0: PartitionOffsets(
+                    'test_topic',
+                    0,
+                    45,
+                    0
+                )
+                }
+            ):
+                with mock.patch.object(
+                    kafka_group_reader,
+                    'process_consumer_offset_message',
+                ) as mock_process_consumer_offset_message:
+                    kafka_group_reader.read_groups()
+                    assert kafka_group_reader.kafka_groups == {}
+                    assert mock_process_consumer_offset_message.call_count == 0
+                    assert len(kafka_group_reader.finished_partitions) == 0
+
+    def test_get_max_offset(self):
+        kafka_config = mock.Mock()
+        kafka_group_reader = KafkaGroupReader(kafka_config)
+        with mock.patch.object(
+            kafka_group_reader,
+            'get_current_watermarks',
+            return_value={0: PartitionOffsets(
+                'test_topic',
+                0,
+                45,
+                0
+            )
+            }
+        ) as mock_get_watermarks:
+            kafka_group_reader.watermarks = mock_get_watermarks()
+            highmark = kafka_group_reader.get_max_offset(0)
+            assert highmark == 45


### PR DESCRIPTION
offset_get ignores --storage option when checking group existence

This will check if storage option is kafka, and in case it is, it will read list of topics form kafka and not from zookeeper. Default option is still zookeeper.
