### PR TITLE
Move pending assignment plan check 

### DIFF
--- a/kafka_utils/kafka_cluster_manager/cmds/command.py
+++ b/kafka_utils/kafka_cluster_manager/cmds/command.py
@@ -79,10 +79,6 @@ class ClusterManagerCmd(object):
     def execute_plan(self, plan, allow_rf_change=False):
         """Save proposed-plan and execute the same if requested."""
         if self.should_execute():
-            # Exit if there is an on-going reassignment
-            if self.is_reassignment_pending():
-                self.log.error('Previous reassignment pending.')
-                sys.exit(1)
             result = self.zk.execute_plan(plan, allow_rf_change=allow_rf_change)
             if not result:
                 self.log.error('Plan execution unsuccessful.')
@@ -121,7 +117,7 @@ class ClusterManagerCmd(object):
         return value
 
     def is_reassignment_pending(self):
-        """Return True if there are no reassignment tasks pending."""
+        """Return True if there are reassignment tasks pending."""
         in_progress_plan = self.zk.get_pending_plan()
         if in_progress_plan:
             in_progress_partitions = in_progress_plan['partitions']

--- a/kafka_utils/kafka_cluster_manager/cmds/command.py
+++ b/kafka_utils/kafka_cluster_manager/cmds/command.py
@@ -71,6 +71,12 @@ class ClusterManagerCmd(object):
             if len(ct.partitions) == 0:
                 self.log.info("The cluster is empty. No actions to perform.")
                 return
+
+            # Exit if there is an on-going reassignment
+            if self.is_reassignment_pending():
+                self.log.error('Previous reassignment pending.')
+                sys.exit(1)
+
             self.run_command(ct)
 
     def add_subparser(self, subparsers):

--- a/kafka_utils/kafka_cluster_manager/cmds/decommission.py
+++ b/kafka_utils/kafka_cluster_manager/cmds/decommission.py
@@ -67,11 +67,6 @@ class DecommissionCmd(ClusterManagerCmd):
         base_assignment = cluster_topology.assignment
         cluster_topology.decommission_brokers(self.args.broker_ids)
 
-        # Exit if there is an on-going reassignment
-        if self.is_reassignment_pending():
-            self.log.error('Previous reassignment pending.')
-            sys.exit(1)
-
         if not validate_plan(
             assignment_to_plan(cluster_topology.assignment),
             assignment_to_plan(base_assignment),

--- a/kafka_utils/kafka_cluster_manager/cmds/decommission.py
+++ b/kafka_utils/kafka_cluster_manager/cmds/decommission.py
@@ -67,6 +67,11 @@ class DecommissionCmd(ClusterManagerCmd):
         base_assignment = cluster_topology.assignment
         cluster_topology.decommission_brokers(self.args.broker_ids)
 
+        # Exit if there is an on-going reassignment
+        if self.is_reassignment_pending():
+            self.log.error('Previous reassignment pending.')
+            sys.exit(1)
+
         if not validate_plan(
             assignment_to_plan(cluster_topology.assignment),
             assignment_to_plan(base_assignment),


### PR DESCRIPTION
KAFKA-2392 Move pending assignment plan check to be a precondition of cluster manager operations so it is more obvious that it could become a blocker