### PR TITLE
Offset manager single partition

### DIFF
--- a/kafka_utils/kafka_consumer_manager/commands/offset_manager.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_manager.py
@@ -130,7 +130,7 @@ class OffsetManagerBase(object):
             groupid
     ):
         kafka_group_reader = KafkaGroupReader(cluster_config)
-        return kafka_group_reader.read_groups().get(groupid, [])
+        return kafka_group_reader.read_group(groupid)
 
     @classmethod
     def get_topics_for_group_from_zookeeper(

--- a/kafka_utils/kafka_consumer_manager/util.py
+++ b/kafka_utils/kafka_consumer_manager/util.py
@@ -154,7 +154,7 @@ class KafkaGroupReader:
         self.finished_partitions = set()
         self.retry_max = 3
 
-    def read_group(self, group_id=None):
+    def read_group(self, group_id):
         partition = get_group_partition(group_id)
         return self.read_groups(partition).get(group_id, [])
 
@@ -224,16 +224,16 @@ class KafkaGroupReader:
         else:  # No offset means group deletion
             self.kafka_groups.pop(group, None)
 
-    def get_current_watermarks(self, consumer_offset_topic_partition=None):
+    def get_current_watermarks(self, partition=None):
         self.consumer._client.load_metadata_for_topics()
         offsets = get_topics_watermarks(
             self.consumer._client,
             [CONSUMER_OFFSET_TOPIC],
         )
-        return {partition: offset for partition, offset
+        return {part: offset for part, offset
                 in offsets[CONSUMER_OFFSET_TOPIC].iteritems()
                 if offset.highmark > offset.lowmark and
-                (partition is None or partition == consumer_offset_topic_partition)}
+                (partition is None or part == partition)}
 
     def get_max_offset(self, partition):
         return self.watermarks[partition].highmark

--- a/kafka_utils/kafka_consumer_manager/util.py
+++ b/kafka_utils/kafka_consumer_manager/util.py
@@ -130,6 +130,15 @@ def prompt_user_input(in_str):
             return
 
 
+# The mapping of group information to partition for the __consumer_offsets
+# topic is determinated by a hash of the group id, modulo the number of
+# partitions in the topic.
+# Kafka code (from main/scala/kafka/coordinator/GroupMetadataManager.scala):
+#   def partitionFor(groupId: String): Int =
+#       Utils.abs(groupId.hashCode) % groupMetadataTopicPartitionCount
+# hashCode returns the hash of the string according to the Java default string
+# hashing algorithm. The algorithm is implemented in the inner function
+# java_string_hashcode.
 def get_group_partition(group):
     """Given a group name, return the partition number of the consumer offset
     topic containing the data associated to that group."""

--- a/kafka_utils/kafka_consumer_manager/util.py
+++ b/kafka_utils/kafka_consumer_manager/util.py
@@ -138,7 +138,7 @@ def get_group_partition(group):
         for c in s:
             h = (31 * h + ord(c)) & 0xFFFFFFFF
         return ((h + 0x80000000) & 0xFFFFFFFF) - 0x80000000
-    return java_string_hashcode(group) % CONSUMER_OFFSET_TOPIC_PARTITIONS
+    return abs(java_string_hashcode(group)) % CONSUMER_OFFSET_TOPIC_PARTITIONS
 
 
 class InvalidMessageException(Exception):

--- a/kafka_utils/kafka_consumer_manager/util.py
+++ b/kafka_utils/kafka_consumer_manager/util.py
@@ -195,7 +195,6 @@ class KafkaGroupReader:
                 self.log.warning("Got %s, retrying", e.__class__.__name__)
         return self.kafka_groups
 
-
     def parse_consumer_offset_message(self, message):
         key = bytearray(message.key)
         ((key_schema,), cur) = relative_unpack(b'>h', key, 0)
@@ -234,7 +233,7 @@ class KafkaGroupReader:
         return {partition: offset for partition, offset
                 in offsets[CONSUMER_OFFSET_TOPIC].iteritems()
                 if offset.highmark > offset.lowmark and
-                    (partition is None or partition == consumer_offset_topic_partition) }
+                (partition is None or partition == consumer_offset_topic_partition)}
 
     def get_max_offset(self, partition):
         return self.watermarks[partition].highmark

--- a/tests/kafka_consumer_manager/test_utils.py
+++ b/tests/kafka_consumer_manager/test_utils.py
@@ -6,6 +6,7 @@ from kafka.common import ConsumerTimeout
 from kafka.common import KafkaMessage
 from kafka.common import LeaderNotAvailableError
 
+from kafka_utils.kafka_consumer_manager.util import get_group_partition
 from kafka_utils.kafka_consumer_manager.util import InvalidMessageException
 from kafka_utils.kafka_consumer_manager.util import KafkaGroupReader
 from kafka_utils.util.offsets import PartitionOffsets
@@ -166,6 +167,15 @@ class TestKafkaGroupReader(object):
                     kafka_group_reader.read_groups()
                     assert kafka_group_reader.kafka_groups['test_group'] == {"test_topic"}
                     assert len(kafka_group_reader.finished_partitions) == 1
+
+    def test_get_group_partition(self):
+        result1 = get_group_partition('815e79b2-be20-11e6-96b6-0697c842cbe5')
+        result2 = get_group_partition('83e3f292-be26-11e6-b509-0697c842cbe5')
+        result3 = get_group_partition('adaceffc-be26-11e6-8eab-0697c842cbe5')
+
+        assert result1 == 10
+        assert result2 == 44
+        assert result3 == 15
 
     def test_read_groups_with_consumer_timeout(self):
 


### PR DESCRIPTION
The kafka-consumer-manager `offset_get` command, when used with offset storage set to `kafka`, reads the entire `__consumer_offsets` topic to find out the list of topics associated with a given group.
Given that `__consumer_offsets` can be several GBs, this can take quite a long time.

With this change, `offset_get` consumes only from the partition that stores the information on the specified group (kafka code [here](https://github.com/apache/kafka/blob/d092673838173d9dedbf5acf3f4e2cd8c736294f/core/src/main/scala/kafka/coordinator/GroupMetadataManager.scala)). This change should give us a 50x speed improvement on average.