### PR TITLE
Do not initialize the kafka offset topic if not needed

### DIFF
--- a/tests/acceptance/steps/util.py
+++ b/tests/acceptance/steps/util.py
@@ -143,8 +143,10 @@ def call_offset_get(group, storage=None, json=False):
 
 
 def initialize_kafka_offsets_topic():
+    if '__consumer_offsets' in list_topics():
+        return
     topic = create_random_topic(1, 1)
     produce_example_msg(topic, num_messages=1)
     create_consumer_group(topic, 'foo')
     call_offset_get('foo', storage='kafka')
-    time.sleep(10)
+    time.sleep(20)


### PR DESCRIPTION
Many tests require the `__consumer_offsets` topic to be present, and each of them tries to create it and waits for 10 seconds. This change will make sure that the initialization will be skipped if the topic already exists, making acceptance tests faster.

The sleep time has been increased since I've seen (rare) cases in which 10 seconds weren't enough. The initialization function will now wait 20 seconds, but only on the first run.