### PR TITLE
Fix storage options

### DIFF
--- a/kafka_utils/kafka_consumer_manager/commands/offset_advance.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_advance.py
@@ -77,6 +77,7 @@ class OffsetAdvance(OffsetWriter):
             args.partitions,
             cluster_config,
             client,
+            storage=args.storage,
             force=args.force,
         )
         try:

--- a/kafka_utils/kafka_consumer_manager/commands/offset_manager.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_manager.py
@@ -177,6 +177,7 @@ class OffsetWriter(OffsetManagerBase):
             partitions,
             cluster_config,
             client,
+            storage=storage,
             fail_on_error=(fail_on_error and not force),
         )
 

--- a/kafka_utils/kafka_consumer_manager/commands/offset_manager.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_manager.py
@@ -69,8 +69,8 @@ class OffsetManagerBase(object):
         topics = cls.get_topics_from_consumer_group_id(
             cluster_config,
             groupid,
-            storage,
-            fail_on_error,
+            storage=storage,
+            fail_on_error=fail_on_error,
         )
         topics_dict = {}
         if topic:

--- a/tests/acceptance/steps/offset_advance.py
+++ b/tests/acceptance/steps/offset_advance.py
@@ -47,6 +47,7 @@ def step_impl3_2(context):
         context.group,
         topic=context.topic,
         storage='kafka',
+        force=True,
     )
 
 

--- a/tests/acceptance/steps/offset_advance.py
+++ b/tests/acceptance/steps/offset_advance.py
@@ -47,7 +47,6 @@ def step_impl3_2(context):
         context.group,
         topic=context.topic,
         storage='kafka',
-        force=True,
     )
 
 

--- a/tests/acceptance/steps/util.py
+++ b/tests/acceptance/steps/util.py
@@ -22,6 +22,7 @@ from kafka.common import LeaderNotAvailableError
 
 from kafka_utils.util import config
 from kafka_utils.util.client import KafkaToolClient
+from kafka_utils.util.offsets import set_consumer_offsets
 
 
 ZOOKEEPER_URL = 'zookeeper:2181'
@@ -147,6 +148,6 @@ def initialize_kafka_offsets_topic():
         return
     topic = create_random_topic(1, 1)
     produce_example_msg(topic, num_messages=1)
-    create_consumer_group(topic, 'foo')
-    call_offset_get('foo', storage='kafka')
+    kafka = KafkaToolClient(KAFKA_URL)
+    set_consumer_offsets(kafka, "group", {topic: {0: 0}}, offset_storage='kafka')
     time.sleep(20)

--- a/tests/acceptance/steps/util.py
+++ b/tests/acceptance/steps/util.py
@@ -149,5 +149,11 @@ def initialize_kafka_offsets_topic():
     topic = create_random_topic(1, 1)
     produce_example_msg(topic, num_messages=1)
     kafka = KafkaToolClient(KAFKA_URL)
-    set_consumer_offsets(kafka, "group", {topic: {0: 0}}, offset_storage='kafka')
+    set_consumer_offsets(
+        kafka,
+        create_random_group_id(),
+        {topic: {0: 0}},
+        offset_storage='kafka',
+        raise_on_error=False,
+    )
     time.sleep(20)


### PR DESCRIPTION
The `offset_advance` command is ignoring the `storage` parameter.

After this fix, the `offset_get` command cannot be used to create the `__consumer_offsets` topic anymore, so I had to call the `set_consumer_offsets` explicitly.