### PR TITLE
Fix flakiness in kafka_consumer_manager list_topics subcommand

### DIFF
--- a/kafka_utils/kafka_consumer_manager/util.py
+++ b/kafka_utils/kafka_consumer_manager/util.py
@@ -234,8 +234,8 @@ class KafkaGroupReader:
 
         if offset:
             self.kafka_groups[group].add(topic)
-        else:  # No offset means group deletion
-            self.kafka_groups.pop(group, None)
+        else:  # No offset means topic deletion
+            self.kafka_groups[group].discard(topic)
 
     def get_current_watermarks(self, partition=None):
         client = KafkaToolClient(self.kafka_config.broker_list)

--- a/tests/kafka_consumer_manager/test_utils.py
+++ b/tests/kafka_consumer_manager/test_utils.py
@@ -81,7 +81,7 @@ class TestKafkaGroupReader(object):
             message = mock.MagicMock(spec=KafkaMessage)
             kafka_group_reader.process_consumer_offset_message(message)
 
-        expected = {'test.a': {'topic1', 'topic2'}, 'my_test2': {'topic3'}}
+        expected = {'test.a': {'topic1', 'topic2'}, 'my_test2': {'topic3'}, 'my_test': {'topic1'}}
         assert kafka_group_reader.kafka_groups == expected
 
     @mock.patch.object(KafkaGroupReader, 'parse_consumer_offset_message')
@@ -117,8 +117,8 @@ class TestKafkaGroupReader(object):
         kafka_config = mock.Mock()
         kafka_group_reader = KafkaGroupReader(kafka_config)
 
-        kafka_group_reader.kafka_groups['test_group'] = {'test_topic'}
-        assert kafka_group_reader.kafka_groups['test_group'] == {'test_topic'}
+        kafka_group_reader.kafka_groups['test_group'] = set(['test_topic'])
+        assert kafka_group_reader.kafka_groups['test_group'] == set(['test_topic'])
 
         with mock.patch.object(
             kafka_group_reader,
@@ -132,7 +132,7 @@ class TestKafkaGroupReader(object):
             autospec=True
         ):
             kafka_group_reader.process_consumer_offset_message('test message')
-            assert kafka_group_reader.kafka_groups == {}
+            assert kafka_group_reader.kafka_groups == {'test_group': set([])}
 
     def test_read_groups(self):
         kafka_config = mock.Mock()


### PR DESCRIPTION
make test
Verified consistency of list_topics subcommand results for statmonster group.