### PR TITLE
Offset get sort output

### DIFF
--- a/kafka_utils/kafka_consumer_manager/commands/offset_get.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_get.py
@@ -75,11 +75,12 @@ class OffsetGet(OffsetManagerBase):
             "-j", "--json", action="store_true",
             help="Export data in json format."
         )
-        parser_offset_get.add_argument(
+        sort_parser = parser_offset_get.add_mutually_exclusive_group()
+        sort_parser.add_argument(
             "--sort-by-distance", action="store_true",
             help="Sort the output by increasing topic distance."
         )
-        parser_offset_get.add_argument(
+        sort_parser.add_argument(
             "--sort-by-distance-percentage", action="store_true",
             help="Sort the output by increasing topic distance percentage."
         )
@@ -87,10 +88,6 @@ class OffsetGet(OffsetManagerBase):
 
     @classmethod
     def run(cls, args, cluster_config):
-        if args.sort_by_distance and args.sort_by_distance_percentage:
-            print("Invalid sorting parameters.", file=sys.stderr)
-            sys.exit(1)
-
         # Setup the Kafka client
         client = KafkaToolClient(cluster_config.broker_list)
         client.load_metadata_for_topics()
@@ -182,7 +179,7 @@ class OffsetGet(OffsetManagerBase):
     def print_output(cls, consumer_offsets_metadata, watermark_filter):
         for topic, metadata_tuples in consumer_offsets_metadata.iteritems():
             diff_sum = sum([t.highmark - t.current for t in metadata_tuples])
-            print ("Topic Name: {topic}  Total difference: {diff}".format(topic=topic, diff=diff_sum))
+            print ("Topic Name: {topic}  Total Distance: {diff}".format(topic=topic, diff=diff_sum))
             for metadata_tuple in metadata_tuples:
                 print (
                     "\tPartition ID: {partition}".format(

--- a/kafka_utils/kafka_consumer_manager/commands/offset_get.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_get.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import sys
+from collections import OrderedDict
 
 from .offset_manager import OffsetManagerBase
 from kafka_utils.util import print_json
@@ -74,10 +75,22 @@ class OffsetGet(OffsetManagerBase):
             "-j", "--json", action="store_true",
             help="Export data in json format."
         )
+        parser_offset_get.add_argument(
+            "--sort-by-distance", action="store_true",
+            help="Sort the output by increasing topic distance."
+        )
+        parser_offset_get.add_argument(
+            "--sort-by-distance-percentage", action="store_true",
+            help="Sort the output by increasing topic distance percentage."
+        )
         parser_offset_get.set_defaults(command=cls.run)
 
     @classmethod
     def run(cls, args, cluster_config):
+        if args.sort_by_distance and args.sort_by_distance_percentage:
+            print("Invalid sorting parameters.", file=sys.stderr)
+            sys.exit(1)
+
         # Setup the Kafka client
         client = KafkaToolClient(cluster_config.broker_list)
         client.load_metadata_for_topics()
@@ -100,6 +113,21 @@ class OffsetGet(OffsetManagerBase):
         )
         client.close()
 
+        if args.sort_by_distance:
+            sorted_offsets = sorted(
+                consumer_offsets_metadata.items(),
+                key=lambda (topic, offsets): sum([o.highmark - o.current for o in offsets])
+            )
+            consumer_offsets_metadata = OrderedDict(sorted_offsets)
+        elif args.sort_by_distance_percentage:
+            sorted_offsets = sorted(
+                consumer_offsets_metadata.items(),
+                key=lambda (topic, offsets): sum(
+                    [cls.percentage_distance(o.highmark, o.current) for o in offsets]
+                )
+            )
+            consumer_offsets_metadata = OrderedDict(sorted_offsets)
+
         if args.json:
             partitions_info = []
             for partitions in consumer_offsets_metadata.values():
@@ -107,8 +135,8 @@ class OffsetGet(OffsetManagerBase):
                     partition_info = partition._asdict()
                     partition_info['offset_distance'] = partition_info['highmark'] - partition_info['current']
                     partition_info['percentage_distance'] = cls.percentage_distance(
-                        int(partition_info['highmark']),
-                        int(partition_info['current'])
+                        partition_info['highmark'],
+                        partition_info['current']
                     )
                     partitions_info.append(partition_info)
             print_json(partitions_info)
@@ -140,7 +168,8 @@ class OffsetGet(OffsetManagerBase):
     @classmethod
     def print_output(cls, consumer_offsets_metadata, watermark_filter):
         for topic, metadata_tuples in consumer_offsets_metadata.iteritems():
-            print ("Topic Name: {topic}".format(topic=topic))
+            total_lag = sum([t.highmark - t.current for t in metadata_tuples])
+            print ("Topic Name: {topic}  Total lag: {lag}".format(topic=topic, lag=total_lag))
             for metadata_tuple in metadata_tuples:
                 print (
                     "\tPartition ID: {partition}".format(
@@ -167,8 +196,8 @@ class OffsetGet(OffsetManagerBase):
                     )
                 if watermark_filter == "all" or watermark_filter == "distance":
                     per_distance = cls.percentage_distance(
-                        int(metadata_tuple.highmark),
-                        int(metadata_tuple.current)
+                        metadata_tuple.highmark,
+                        metadata_tuple.current
                     )
                     print(
                         "\t\tOffset Distance: {distance}".format(
@@ -184,6 +213,8 @@ class OffsetGet(OffsetManagerBase):
     @classmethod
     def percentage_distance(cls, highmark, current):
         """Percentage of distance the current offset is behind the highmark."""
+        highmark = int(highmark)
+        current = int(current)
         if highmark > 0:
             return round(
                 (highmark - current) * 100.0 / highmark,

--- a/kafka_utils/kafka_consumer_manager/commands/offset_get.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_get.py
@@ -144,8 +144,8 @@ class OffsetGet(OffsetManagerBase):
 
     @classmethod
     def sort_by_distance(cls, consumer_offsets_metadata):
-        """Receives a dict of (topic_name: ConsumerPartitionOffset) and return an
-        equivalent dict where the topics are sorted by total offset distance."""
+        """Receives a dict of (topic_name: ConsumerPartitionOffset) and returns a
+        similar dict where the topics are sorted by total offset distance."""
         sorted_offsets = sorted(
             consumer_offsets_metadata.items(),
             key=lambda (topic, offsets): sum([o.highmark - o.current for o in offsets])
@@ -154,8 +154,8 @@ class OffsetGet(OffsetManagerBase):
 
     @classmethod
     def sort_by_distance_percentage(cls, consumer_offsets_metadata):
-        """Receives a dict of (topic_name: ConsumerPartitionOffset) and return an
-        equivalent dict where the topics are sorted by average offset distance
+        """Receives a dict of (topic_name: ConsumerPartitionOffset) and returns an
+        similar dict where the topics are sorted by average offset distance
         in percentage."""
         sorted_offsets = sorted(
             consumer_offsets_metadata.items(),
@@ -181,8 +181,8 @@ class OffsetGet(OffsetManagerBase):
     @classmethod
     def print_output(cls, consumer_offsets_metadata, watermark_filter):
         for topic, metadata_tuples in consumer_offsets_metadata.iteritems():
-            total_lag = sum([t.highmark - t.current for t in metadata_tuples])
-            print ("Topic Name: {topic}  Total lag: {lag}".format(topic=topic, lag=total_lag))
+            diff_sum = sum([t.highmark - t.current for t in metadata_tuples])
+            print ("Topic Name: {topic}  Total difference: {diff}".format(topic=topic, diff=diff_sum))
             for metadata_tuple in metadata_tuples:
                 print (
                     "\tPartition ID: {partition}".format(

--- a/tests/acceptance/offset_get.feature
+++ b/tests/acceptance/offset_get.feature
@@ -22,7 +22,7 @@ Feature: kafka_consumer_manager offset_get subcommand
       when we fetch offsets for the group with the kafka option
       then the fetched offsets will match the committed offsets
 
-  @kafka_offset_storage	
+  @kafka_offset_storage
   Scenario: Committing offsets into Kafka and fetching offsets with dual option
      Given we have an existing kafka cluster with a topic
      Given we have initialized kafka offsets storage


### PR DESCRIPTION
Sorting the output of offset_get by total lag for each topic is useful in case a consumer is consuming from many topics and we want to find which one or how many of them are lagging behind by a considerable amount.