### PR TITLE
Update kafka-python requirement in kafka utils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         "fabric>=1.8.0,<1.11.0",
         "PyYAML<4.0.0",
         "requests-futures>0.9.0",
-        "kafka-python==1.3.2",
+        "kafka-python>=1.3.2,<1.4.0",
         "requests<3.0.0",
         'retrying'
     ],


### PR DESCRIPTION
Let's not pin it down to an exact version so it is compatible with post version from our kafka-python fork