### PR TITLE
Fix terminate() for exceptional cases

### DIFF
--- a/kafka_utils/kafka_check/commands/command.py
+++ b/kafka_utils/kafka_check/commands/command.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from kafka_utils.kafka_check import status_code
+from kafka_utils.kafka_check.status_code import prepare_terminate_message
 from kafka_utils.kafka_check.status_code import terminate
 from kafka_utils.util.zookeeper import ZK
 
@@ -49,13 +50,19 @@ class KafkaCheckCmd(object):
             if args.controller_only and not is_controller(self.zk, args.broker_id):
                 terminate(
                     status_code.OK,
-                    'Broker %s is not the controller, nothing to check' % (args.broker_id),
+                    prepare_terminate_message(
+                        'Broker {} is not the controller, nothing to check'
+                        .format(args.broker_id),
+                    ),
                     args.json,
                 )
             if args.first_broker_only and not is_first_broker(self.zk, args.broker_id):
                 terminate(
                     status_code.OK,
-                    'Broker %s is not the lowest id, nothing to check' % (args.broker_id),
+                    prepare_terminate_message(
+                        'Broker {} has not the lowest id, nothing to check'
+                        .format(args.broker_id),
+                    ),
                     args.json,
                 )
             return self.run_command()

--- a/kafka_utils/kafka_check/main.py
+++ b/kafka_utils/kafka_check/main.py
@@ -27,6 +27,7 @@ from kafka_utils.kafka_check.commands.min_isr import MinIsrCmd
 from kafka_utils.kafka_check.commands.offline import OfflineCmd
 from kafka_utils.kafka_check.commands.under_replicated import UnderReplicatedCmd
 from kafka_utils.kafka_check.metadata_file import get_broker_id
+from kafka_utils.kafka_check.status_code import prepare_terminate_message
 from kafka_utils.kafka_check.status_code import terminate
 from kafka_utils.util import config
 from kafka_utils.util.error import ConfigurationError
@@ -128,20 +129,26 @@ def run():
     if args.controller_only and args.first_broker_only:
         terminate(
             status_code.WARNING,
-            "Only one of controller_only and first_broker_only should be used",
+            prepare_terminate_message(
+                "Only one of controller_only and first_broker_only should be used",
+            ),
             args.json,
         )
 
     if args.controller_only or args.first_broker_only:
         if args.broker_id is None:
-            terminate(status_code.WARNING, "broker_id is not specified", args.json)
+            terminate(
+                status_code.WARNING,
+                prepare_terminate_message("broker_id is not specified"),
+                args.json,
+            )
         elif args.broker_id == -1:
             try:
                 args.broker_id = get_broker_id(args.data_path)
             except Exception as e:
                 terminate(
                     status_code.WARNING,
-                    "{}".format(e),
+                    prepare_terminate_message("{}".format(e)),
                     args.json,
                 )
 
@@ -153,6 +160,10 @@ def run():
         )
         code, msg = args.command(cluster_config, args)
     except ConfigurationError as e:
-        terminate(status_code.CRITICAL, "ConfigurationError {0}".format(e), args.json)
+        terminate(
+            status_code.CRITICAL,
+            prepare_terminate_message("ConfigurationError {0}".format(e)),
+            args.json,
+        )
 
     terminate(code, msg, args.json)

--- a/kafka_utils/kafka_check/status_code.py
+++ b/kafka_utils/kafka_check/status_code.py
@@ -29,6 +29,13 @@ STATUS_STRING = {
 }
 
 
+def prepare_terminate_message(string):
+    return {
+        'message': string,
+        'raw': string,
+    }
+
+
 def terminate(signal, msg, json):
     if json:
         output = {


### PR DESCRIPTION
Use function prepare_terminate_message() to convert error messages to
dict for passing it into terminate() function.