### PR TITLE
Add global event

### DIFF
--- a/kafka_utils/kafka_rolling_restart/event.py
+++ b/kafka_utils/kafka_rolling_restart/event.py
@@ -1,4 +1,6 @@
 class Event(object):
+    """Class to be used to start/perform events before and after
+    rolling restart"""
 
     def __init__(self, opts):
         self.opts = opts

--- a/kafka_utils/kafka_rolling_restart/event.py
+++ b/kafka_utils/kafka_rolling_restart/event.py
@@ -1,0 +1,10 @@
+class Event(object):
+
+    def __init__(self, opts):
+        self.opts = opts
+
+    def start(self):
+        raise NotImplementedError("implemented in subclass")
+
+    def stop(self):
+        raise NotImplementedError("implemneted in subclass")

--- a/kafka_utils/kafka_rolling_restart/main.py
+++ b/kafka_utils/kafka_rolling_restart/main.py
@@ -145,7 +145,7 @@ def parse_opts():
     parser.add_argument(
         '--global-event',
         type=str,
-        help='Module containing an implementation of Task.'
+        help='Module containing an implementation of Event.'
         'This would be run before the start of the rolling restart,'
         'and after the end of the rolling restart. This can be used as a way to emit events,'
         'or serve as a notification etc.'

--- a/kafka_utils/kafka_rolling_restart/main.py
+++ b/kafka_utils/kafka_rolling_restart/main.py
@@ -31,6 +31,7 @@ from fabric.api import task
 from requests.exceptions import RequestException
 from requests_futures.sessions import FuturesSession
 
+from .event import Event
 from .task import PostStopTask
 from .task import PreStopTask
 from .task import TaskFailedException
@@ -140,6 +141,14 @@ def parse_opts():
         type=str,
         action='append',
         help='Arguements which are needed by the task(prestoptask or poststoptask).'
+    )
+    parser.add_argument(
+        '--global-event',
+        type=str,
+        help='Module containing an implementation of Task.'
+        'This would be run before the start of the rolling restart,'
+        'and after the end of the rolling restart. This can be used as a way to emit events,'
+        'or serve as a notification etc.'
     )
     return parser.parse_args()
 
@@ -454,11 +463,17 @@ def run():
     brokers = get_broker_list(cluster_config)
     if validate_opts(opts, len(brokers)):
         sys.exit(1)
-    pre_stop_tasks, post_stop_tasks = get_task_class(opts.task, opts.task_args)
+    global_task = dynamic_import(opts.global_event, Event)(opts)
+    pre_stop_tasks = []
+    post_stop_tasks = []
+    if opts.task:
+        pre_stop_tasks, post_stop_tasks = get_task_class(opts.task, opts.task_args)
     print_brokers(cluster_config, brokers[opts.skip:])
     if opts.no_confirm or ask_confirmation():
         print("Execute restart")
         try:
+            if global_task:
+                global_task.start()
             execute_rolling_restart(
                 brokers,
                 opts.jolokia_port,
@@ -477,3 +492,6 @@ def run():
         except WaitTimeoutException:
             print("ERROR: cluster is still unhealthy, exiting")
             sys.exit(1)
+        finally:
+            if global_task:
+                global_task.stop()

--- a/kafka_utils/kafka_rolling_restart/main.py
+++ b/kafka_utils/kafka_rolling_restart/main.py
@@ -451,6 +451,7 @@ def get_task_class(tasks, task_args):
 
 def run():
     opts = parse_opts()
+    global_event = None
     if opts.verbose:
         logging.basicConfig(level=logging.DEBUG)
     else:
@@ -463,7 +464,8 @@ def run():
     brokers = get_broker_list(cluster_config)
     if validate_opts(opts, len(brokers)):
         sys.exit(1)
-    global_task = dynamic_import(opts.global_event, Event)(opts)
+    if opts.global_event:
+        global_event = dynamic_import(opts.global_event, Event)(opts)
     pre_stop_tasks = []
     post_stop_tasks = []
     if opts.task:
@@ -472,8 +474,8 @@ def run():
     if opts.no_confirm or ask_confirmation():
         print("Execute restart")
         try:
-            if global_task:
-                global_task.start()
+            if global_event:
+                global_event.start()
             execute_rolling_restart(
                 brokers,
                 opts.jolokia_port,
@@ -493,5 +495,5 @@ def run():
             print("ERROR: cluster is still unhealthy, exiting")
             sys.exit(1)
         finally:
-            if global_task:
-                global_task.stop()
+            if global_event:
+                global_event.stop()


### PR DESCRIPTION
Refers to internal ticket KAFKA-4276, and provides an ability to add global events, which be run before the start and end of rolling restart. 
The aim internally is to tie these to signalfx, so that we can view when these rolling restart activities are performed