### PR TITLE
set upper limit of kafka python to 1.3.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         "fabric>=1.8.0,<1.11.0",
         "PyYAML<4.0.0",
         "requests-futures>0.9.0",
-        "kafka-python>=1.3.2,<1.4.0",
+        "kafka-python>=1.3.2,<1.3.3",
         "requests<3.0.0",
         'retrying'
     ],


### PR DESCRIPTION
Now that we have a new upstream version as 1.3.3, our builds are breaking. Lets set upper limit to 1.3.3 instead of 1.4.0