### PR TITLE
Refactor kafka group reader

### DIFF
--- a/kafka_utils/kafka_consumer_manager/commands/list_groups.py
+++ b/kafka_utils/kafka_consumer_manager/commands/list_groups.py
@@ -37,7 +37,7 @@ class ListGroups(OffsetManagerBase):
             '--storage',
             choices=['zookeeper', 'kafka', 'dual'],
             help="String describing where to fetch the committed offsets.",
-            default='dual'
+            default='kafka'
         )
         parser_list_groups.set_defaults(command=cls.run)
 
@@ -57,13 +57,7 @@ class ListGroups(OffsetManagerBase):
     def get_kafka_groups(cls, cluster_config):
         '''Get the group_id of groups committed into Kafka.'''
         kafka_group_reader = KafkaGroupReader(cluster_config)
-        try:
-            return kafka_group_reader.read_groups().keys()
-        except:
-            print(
-                "Error: No consumer offsets topic found in Kafka",
-                file=sys.stderr,
-            )
+        return kafka_group_reader.read_groups().keys()
 
     @classmethod
     def print_groups(cls, groups, cluster_config):

--- a/kafka_utils/kafka_consumer_manager/util.py
+++ b/kafka_utils/kafka_consumer_manager/util.py
@@ -215,7 +215,7 @@ class KafkaGroupReader:
                 message = self.consumer.next()
             except StopIteration:
                 continue
-            # Stop when reaching the last message writter to the
+            # Stop when reaching the last message written to the
             # __consumer_offsets topic when KafkaGroupReader first started
             if message.offset >= self.watermarks[message.partition].highmark - 1:
                 self.remove_partition_from_consumer(message.partition)

--- a/kafka_utils/kafka_consumer_manager/util.py
+++ b/kafka_utils/kafka_consumer_manager/util.py
@@ -215,6 +215,8 @@ class KafkaGroupReader:
                 message = self.consumer.next()
             except StopIteration:
                 continue
+            # Stop when reaching the last message writter to the
+            # __consumer_offsets topic when KafkaGroupReader first started
             if message.offset >= self.watermarks[message.partition].highmark - 1:
                 self.remove_partition_from_consumer(message.partition)
             self.process_consumer_offset_message(message)

--- a/tests/kafka_consumer_manager/test_list_groups.py
+++ b/tests/kafka_consumer_manager/test_list_groups.py
@@ -83,21 +83,6 @@ class TestListGroups(object):
             assert m.read_groups.call_count == 1
 
     @mock.patch("kafka_utils.kafka_consumer_manager.commands.list_groups.print", create=True)
-    def test_get_kafka_groups_error(self, mock_print):
-        with self.mock_kafka_info() as (_, mock_kafka_reader):
-            m = mock_kafka_reader.return_value
-            m.read_groups.side_effect = Exception("Boom!")
-
-            cluster_config = mock.Mock(zookeeper='some_ip', type='some_cluster_type')
-            cluster_config.configure_mock(name='some_cluster_name')
-
-            ListGroups.get_kafka_groups(cluster_config)
-            mock_print.assert_any_call(
-                "Error: No consumer offsets topic found in Kafka",
-                file=sys.stderr,
-            )
-
-    @mock.patch("kafka_utils.kafka_consumer_manager.commands.list_groups.print", create=True)
     def test_print_groups(self, mock_print):
         groups = ['group1', 'group2', 'group3']
 


### PR DESCRIPTION
- Fix a bug when the __consumer_offsets consumer would take very long to scan the entire topic
- Fix a bug when the __consumer_offsets consumer would interrupt scanning the topic because of a timeout
- Add logging

Scanning the entire log takes quite some time, about 3-5 minutes on average.
Fixes #106 