### PR TITLE
Run integration tests for Kafka 0.10.1.1 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ script:
 - tox
 - tox -e docker_itest_8
 - tox -e docker_itest_9
+- tox -e docker_itest_10
 deploy:
   provider: pypi
   user: yelplabs


### PR DESCRIPTION
The integration tests for 0.10.1.1 weren't actually being run on Travis. They pass though, so that's great!