### PR TITLE
Split the tox file and fix the test cleanup to run acceptance locally

### DIFF
--- a/docker/itest_0.10.1.1/run_tests.sh
+++ b/docker/itest_0.10.1.1/run_tests.sh
@@ -5,7 +5,7 @@ set -e
 function do_at_exit {
   exit_status=$?
   rm -rf build/ dist/ kafka_utils.egg-info/
-  rm -rf .tox/log .tox/${ITEST_PYTHON_FACTOR}-acceptance
+  rm -rf .tox/log .tox/${ITEST_PYTHON_FACTOR}-acceptance .tox/dist_acceptance
   find . -name '*.pyc' -delete
   find . -name '__pycache__' -delete
   exit $exit_status
@@ -14,4 +14,4 @@ function do_at_exit {
 # Clean up artifacts from tests
 trap do_at_exit EXIT INT TERM
 
-tox -e ${ITEST_PYTHON_FACTOR}-acceptance
+tox -c tox_acceptance.ini -e ${ITEST_PYTHON_FACTOR}-acceptance

--- a/docker/itest_0.8.2/run_tests.sh
+++ b/docker/itest_0.8.2/run_tests.sh
@@ -5,13 +5,13 @@ set -e
 function do_at_exit {
   exit_status=$?
   rm -rf build/ dist/ kafka_utils.egg-info/
-  rm -rf .tox/log .tox/${ITEST_PYTHON_FACTOR}-acceptance
+  rm -rf .tox/log .tox/${ITEST_PYTHON_FACTOR}-acceptance .tox/dist_acceptance
   find . -name '*.pyc' -delete
-  find . -name '__pycache__' -print0 | xargs -0 rm -rf
+  find . -name '__pycache__' -delete
   exit $exit_status
 }
 
 # Clean up artifacts from tests
 trap do_at_exit EXIT INT TERM
 
-tox -e ${ITEST_PYTHON_FACTOR}-acceptance
+tox -c tox_acceptance.ini -e ${ITEST_PYTHON_FACTOR}-acceptance

--- a/docker/itest_0.9.0/run_tests.sh
+++ b/docker/itest_0.9.0/run_tests.sh
@@ -5,7 +5,7 @@ set -e
 function do_at_exit {
   exit_status=$?
   rm -rf build/ dist/ kafka_utils.egg-info/
-  rm -rf .tox/log .tox/${ITEST_PYTHON_FACTOR}-acceptance
+  rm -rf .tox/log .tox/${ITEST_PYTHON_FACTOR}-acceptance .tox/dist_acceptance
   find . -name '*.pyc' -delete
   find . -name '__pycache__' -delete
   exit $exit_status
@@ -14,4 +14,4 @@ function do_at_exit {
 # Clean up artifacts from tests
 trap do_at_exit EXIT INT TERM
 
-tox -e ${ITEST_PYTHON_FACTOR}-acceptance
+tox -c tox_acceptance.ini -e ${ITEST_PYTHON_FACTOR}-acceptance

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-ipdb==0.10.0
+ipdb==0.10.3
 ipython==4.2.0
 ipython-genutils==0.1.0
 pre-commit==0.8.0

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ deps =
     flake8
     pytest
     mock
-    acceptance: behave
     dockeritest: docker-compose==1.6.2
 whitelist_externals = /bin/bash
 passenv = ITEST_PYTHON_FACTOR KAFKA_VERSION ACCEPTANCE_TAGS
@@ -42,11 +41,6 @@ commands =
     dockeritest:     -e ACCEPTANCE_TAGS={env:ACCEPTANCE_TAGS} \
     dockeritest:     itest /scripts/run_tests.sh; exit_status=$?; \
     dockeritest:   docker-compose stop; exit $exit_status"
-
-    acceptance: /bin/bash -c 'echo "Running acceptance tests using" $({envbindir}/python --version)'
-    acceptance: /bin/bash -c 'env'
-    acceptance: /bin/bash -c 'behave tests/acceptance --tags=$ACCEPTANCE_TAGS --no-capture'
-
 
 [testenv:coverage]
 deps =

--- a/tox_acceptance.ini
+++ b/tox_acceptance.ini
@@ -1,0 +1,35 @@
+[tox]
+envlist = py{27,34,35,36}-unittest, py{27,34,35,36}-kafka{8,9,10}-dockeritest
+distdir = {toxworkdir}/dist_acceptance
+
+[travis]
+python =
+  py27: py27-kafka{8,9,10}-dockeritest
+  py34: py34-kafka{8,9,10}-dockeritest
+  py35: py35-kafka{8,9,10}-dockeritest
+  py36: py36-kafka{8,9,10}-dockeritest
+
+[testenv]
+deps =
+    -rrequirements-dev.txt
+    flake8
+    pytest
+    mock
+    acceptance: behave
+whitelist_externals = /bin/bash
+passenv = ITEST_PYTHON_FACTOR KAFKA_VERSION ACCEPTANCE_TAGS
+setenv =
+    py27: ITEST_PYTHON_FACTOR = py27
+    py34: ITEST_PYTHON_FACTOR = py34
+    py35: ITEST_PYTHON_FACTOR = py35
+    py36: ITEST_PYTHON_FACTOR = py36
+    kafka8: KAFKA_VERSION = 0.8.2
+    kafka8: ACCEPTANCE_TAGS = ~kafka_offset_storage
+    kafka9: KAFKA_VERSION = 0.9.0
+    kafka9: ACCEPTANCE_TAGS = ~kafka10
+    kafka10: KAFKA_VERSION = 0.10.1.1
+    kafka10: ACCEPTANCE_TAGS = ~kafka9
+commands =
+    acceptance: /bin/bash -c 'echo "Running acceptance tests using" $({envbindir}/python --version)'
+    acceptance: /bin/bash -c 'env'
+    acceptance: /bin/bash -c 'behave tests/acceptance --tags=$ACCEPTANCE_TAGS --no-capture'


### PR DESCRIPTION
I had to split up the tox file to use two separate distdir.
distdir was causing issues when running acceptance locally so I added that to the list of directories to remove upon test termination.