### PR TITLE
Add support for partition and leader count in generic balancer

### DIFF
--- a/kafka_utils/kafka_cluster_manager/cluster_info/display.py
+++ b/kafka_utils/kafka_cluster_manager/cluster_info/display.py
@@ -181,7 +181,7 @@ def display_partition_imbalance(cluster_topologies):
                 name='' if len(cluster_topologies) == 1 else name + '\n',
                 net_imbalance=stats.get_net_imbalance(bpc),
                 weight_mean=stats.mean(bw),
-                weight_stdev=stats.standard_deviation_p(bw),
+                weight_stdev=stats.stdevp(bw),
                 weight_cv=stats.coefficient_of_variation(bw),
             )
         )
@@ -248,7 +248,7 @@ def display_leader_imbalance(cluster_topologies):
                 name='' if len(cluster_topologies) == 1 else name + '\n',
                 net_imbalance=stats.get_net_imbalance(blc),
                 weight_mean=stats.mean(blw),
-                weight_stdev=stats.standard_deviation_p(blw),
+                weight_stdev=stats.stdevp(blw),
                 weight_cv=stats.coefficient_of_variation(blw),
             )
         )

--- a/kafka_utils/kafka_cluster_manager/cluster_info/display.py
+++ b/kafka_utils/kafka_cluster_manager/cluster_info/display.py
@@ -181,7 +181,7 @@ def display_partition_imbalance(cluster_topologies):
                 name='' if len(cluster_topologies) == 1 else name + '\n',
                 net_imbalance=stats.get_net_imbalance(bpc),
                 weight_mean=stats.mean(bw),
-                weight_stdev=stats.standard_deviation(bw),
+                weight_stdev=stats.standard_deviation_p(bw),
                 weight_cv=stats.coefficient_of_variation(bw),
             )
         )
@@ -248,7 +248,7 @@ def display_leader_imbalance(cluster_topologies):
                 name='' if len(cluster_topologies) == 1 else name + '\n',
                 net_imbalance=stats.get_net_imbalance(blc),
                 weight_mean=stats.mean(blw),
-                weight_stdev=stats.standard_deviation(blw),
+                weight_stdev=stats.standard_deviation_p(blw),
                 weight_cv=stats.coefficient_of_variation(blw),
             )
         )

--- a/kafka_utils/kafka_cluster_manager/cluster_info/genetic_balancer.py
+++ b/kafka_utils/kafka_cluster_manager/cluster_info/genetic_balancer.py
@@ -49,10 +49,10 @@ DEFAULT_MAX_EXPLORATION = 10000
 # In practice, overall weight is more important than leader weight which is
 # more important than topic-broker imbalance so different weights are used
 # to adjust for this.
-DEFAULT_PARTITION_WEIGHT_CV_SCORE_WEIGHT = 0.6
-DEFAULT_LEADER_WEIGHT_CV_SCORE_WEIGHT = 0.3
-DEFAULT_TOPIC_BROKER_IMBALANCE_SCORE_WEIGHT = 0.2
-DEFAULT_BROKER_PARTITION_COUNT_SCORE_WEIGHT = 0.2
+DEFAULT_PARTITION_WEIGHT_CV_SCORE_WEIGHT = 0.50
+DEFAULT_LEADER_WEIGHT_CV_SCORE_WEIGHT = 0.25
+DEFAULT_TOPIC_BROKER_IMBALANCE_SCORE_WEIGHT = 0.1
+DEFAULT_BROKER_PARTITION_COUNT_SCORE_WEIGHT = 0.15
 # Movement size is included in the scoring function to prevent fewer large
 # movements from being favored over more smaller movements (since only one
 # partition is moved each generation). This weight is smaller than the others
@@ -567,7 +567,7 @@ class GeneticBalancer(ClusterBalancer):
             score += self.args.topic_broker_imbalance_score_weight * \
                 (1 - state.weighted_topic_broker_imbalance)
             score += self.args.broker_partition_count_score_weight * \
-                (1 - state.broker_partition_count_cv)
+                (1 - state.broker_partition_count_cv / sqrt(len(state.brokers)))
             max_score += self.args.partition_weight_cv_score_weight
             max_score += self.args.leader_weight_cv_score_weight
             max_score += self.args.topic_broker_imbalance_score_weight

--- a/kafka_utils/kafka_cluster_manager/cluster_info/genetic_balancer.py
+++ b/kafka_utils/kafka_cluster_manager/cluster_info/genetic_balancer.py
@@ -571,6 +571,7 @@ class GeneticBalancer(ClusterBalancer):
             max_score += self.args.partition_weight_cv_score_weight
             max_score += self.args.leader_weight_cv_score_weight
             max_score += self.args.topic_broker_imbalance_score_weight
+            max_score += self.args.broker_partition_count_score_weight
 
         if self.args.max_movement_size is not None and score_movement:
             score += self.args.movement_size_score_weight * \

--- a/kafka_utils/kafka_cluster_manager/cluster_info/stats.py
+++ b/kafka_utils/kafka_cluster_manager/cluster_info/stats.py
@@ -39,7 +39,7 @@ def variance(data, data_mean=None):
     return sum((x - data_mean) ** 2 for x in data) / len(data)
 
 
-def standard_deviation(data, data_mean=None, data_variance=None):
+def standard_deviation_p(data, data_mean=None, data_variance=None):
     """Return standard deviation of a sequence of numbers.
     :param data_mean: Precomputed mean of the sequence.
     :param data_variance: Precomputed variance of the sequence.
@@ -51,11 +51,11 @@ def standard_deviation(data, data_mean=None, data_variance=None):
 def coefficient_of_variation(data, data_mean=None, data_stdev=None):
     """Return the coefficient of variation (CV) of a sequence of numbers.
     :param data_mean: Precomputed mean of the sequence.
-    :param data_standard_deviation: Precomputed standard_deviation of the
+    :param data_standard_deviation_p: Precomputed standard_deviation_p of the
         sequence.
     """
     data_mean = data_mean or mean(data)
-    data_stdev = data_stdev or standard_deviation(data, data_mean)
+    data_stdev = data_stdev or standard_deviation_p(data, data_mean)
     if data_mean == 0:
         return float("inf") if data_stdev != 0 else 0
     else:

--- a/kafka_utils/kafka_cluster_manager/cluster_info/stats.py
+++ b/kafka_utils/kafka_cluster_manager/cluster_info/stats.py
@@ -39,7 +39,7 @@ def variance(data, data_mean=None):
     return sum((x - data_mean) ** 2 for x in data) / len(data)
 
 
-def standard_deviation_p(data, data_mean=None, data_variance=None):
+def stdevp(data, data_mean=None, data_variance=None):
     """Return standard deviation of a sequence of numbers.
     :param data_mean: Precomputed mean of the sequence.
     :param data_variance: Precomputed variance of the sequence.
@@ -51,11 +51,11 @@ def standard_deviation_p(data, data_mean=None, data_variance=None):
 def coefficient_of_variation(data, data_mean=None, data_stdev=None):
     """Return the coefficient of variation (CV) of a sequence of numbers.
     :param data_mean: Precomputed mean of the sequence.
-    :param data_standard_deviation_p: Precomputed standard_deviation_p of the
+    :param data_stdevp: Precomputed stdevp of the
         sequence.
     """
     data_mean = data_mean or mean(data)
-    data_stdev = data_stdev or standard_deviation_p(data, data_mean)
+    data_stdev = data_stdev or stdevp(data, data_mean)
     if data_mean == 0:
         return float("inf") if data_stdev != 0 else 0
     else:

--- a/tests/kafka_cluster_manager/genetic_balancer_test.py
+++ b/tests/kafka_cluster_manager/genetic_balancer_test.py
@@ -404,6 +404,12 @@ class Test_State(object):
         """Test that the state assignment matches the default_assignment."""
         assert self.state.assignment == default_assignment
 
+    def test_broker_partition_count_cv(self):
+        """Test that broker_partition_count_cv returns the correct value for the
+        default assignment.
+        """
+        assert abs(self.state.broker_partition_count_cv - 0.4527) < 1e-4
+
     def test_broker_weight_cv(self):
         """Test that broker_weight_cv returns the correct value for the
         default assignment.
@@ -438,6 +444,7 @@ class Test_State(object):
             (0, 1, 2),
             (0, 1, 4),
         )
+        assert new_state.broker_partition_counts == (4, 5, 5, 3, 2)
         assert new_state.broker_weights == (24, 26, 23, 12, 12)
         assert new_state.broker_leader_weights == (24, 2, 9, 0, 0)
         assert new_state.topic_broker_count == (
@@ -447,6 +454,7 @@ class Test_State(object):
             (2, 2, 1, 0, 1),
         )
         assert new_state.topic_broker_imbalance == (1, 0, 0, 1)
+        assert abs(new_state.broker_partition_count_cv - 0.3068) < 1e-4
         assert abs(new_state.broker_weight_cv - 0.3154) < 1e-4
         assert abs(new_state.broker_leader_weight_cv - 1.3030) < 1e-4
         assert abs(new_state.weighted_topic_broker_imbalance - 55 / 97) < 1e-4
@@ -474,6 +482,7 @@ class Test_State(object):
             (0, 1, 2),
             (0, 1, 4),
         )
+        assert new_state.broker_partition_counts == (4, 5, 5, 4, 1)
         assert new_state.broker_weights == (24, 26, 21, 18, 8)
         assert new_state.broker_leader_weights == (24, 2, 3, 6, 0)
         assert new_state.topic_broker_count == (
@@ -483,6 +492,7 @@ class Test_State(object):
             (2, 2, 1, 0, 1),
         )
         assert new_state.topic_broker_imbalance == (1, 1, 0, 1)
+        assert abs(new_state.broker_partition_count_cv - 0.3867) < 1e-4
         assert abs(new_state.broker_weight_cv - 0.3254) < 1e-4
         assert abs(new_state.broker_leader_weight_cv - 1.2453) < 1e-4
         assert abs(new_state.weighted_topic_broker_imbalance - 91 / 97) < 1e-4
@@ -511,6 +521,7 @@ class Test_State(object):
             (0, 1, 2),
             (3, 1, 4),
         )
+        assert new_state.broker_partition_counts == (3, 4, 5, 4, 3)
         assert new_state.broker_weights == (16, 21, 24, 20, 16)
         assert new_state.broker_leader_weights == (16, 2, 6, 8, 3)
         assert new_state.topic_broker_count == (
@@ -520,6 +531,7 @@ class Test_State(object):
             (1, 2, 1, 1, 1),
         )
         assert new_state.topic_broker_imbalance == (0, 0, 0, 0)
+        assert abs(new_state.broker_partition_count_cv - 0.1969) < 1e-4
         assert abs(new_state.broker_weight_cv - 0.1584) < 1e-4
         assert abs(new_state.broker_leader_weight_cv - 0.7114) < 1e-4
         assert new_state.weighted_topic_broker_imbalance == 0
@@ -547,6 +559,7 @@ class Test_State(object):
             (0, 1, 2),
             (0, 1, 4),
         )
+        assert new_state.broker_partition_counts == (4, 5, 6, 3, 1)
         assert new_state.broker_leader_weights == (19, 2, 14, 0, 0)
         assert abs(new_state.broker_leader_weight_cv - 1.1357) < 1e-4
         assert new_state.rg_replicas == (
@@ -573,6 +586,7 @@ class Test_State(object):
             (0, 1, 2),
             (0, 1, 4),
         )
+        assert new_state.broker_partition_counts == (4, 5, 6, 3, 2)
         assert new_state.broker_weights == (24, 26, 27, 12, 14)
         assert new_state.broker_leader_weights == (24, 2, 9, 0, 0)
         assert new_state.topic_broker_count == (
@@ -582,6 +596,7 @@ class Test_State(object):
             (2, 2, 1, 0, 1),
         )
         assert new_state.topic_broker_imbalance == (1, 1, 0, 1)
+        assert abs(new_state.broker_partition_count_cv - 0.3535) < 1e-4
         assert abs(new_state.broker_weight_cv - 0.3064) < 1e-4
         assert abs(new_state.broker_leader_weight_cv - 1.3030) < 1e-4
         assert abs(new_state.weighted_topic_broker_imbalance - 91 / 103) < 1e-4
@@ -609,6 +624,7 @@ class Test_State(object):
             (0, 1),
             (0, 1, 4),
         )
+        assert new_state.broker_partition_counts == (4, 5, 5, 3, 1)
         assert new_state.broker_weights == (24, 26, 20, 12, 8)
         assert new_state.broker_leader_weights == (24, 2, 9, 0, 0)
         assert new_state.topic_broker_count == (
@@ -621,6 +637,7 @@ class Test_State(object):
         assert abs(new_state.broker_weight_cv - 0.3849) < 1e-4
         assert abs(new_state.broker_leader_weight_cv - 1.3030) < 1e-4
         assert abs(new_state.weighted_topic_broker_imbalance - 122 / 90) < 1e-4
+        assert abs(new_state.broker_partition_count_cv - 0.4157) < 1e-4
         assert new_state.rg_replicas == (
             (1, 0, 2, 2, 0, 2, 3),
             (1, 2, 2, 2, 1, 0, 0),

--- a/tests/kafka_cluster_manager/genetic_balancer_test.py
+++ b/tests/kafka_cluster_manager/genetic_balancer_test.py
@@ -356,6 +356,12 @@ class Test_State(object):
         """
         assert self.state.broker_leader_weights == (24, 2, 9, 0, 0)
 
+    def test_broker_leader_counts(self):
+        """Test that the broker leader count map has been correctly
+        initialized.
+        """
+        assert self.state.broker_leader_counts == (4, 1, 2, 0, 0)
+
     def test_total_weight(self):
         """Test that the total weight has been correctly initialized."""
         assert self.state.total_weight == 97
@@ -422,6 +428,12 @@ class Test_State(object):
         """
         assert abs(self.state.broker_leader_weight_cv - 1.3030) < 1e-4
 
+    def test_broker_leader_count_cv(self):
+        """Test that broker_leader_count_cv returns the correct value for the
+        default assignment.
+        """
+        assert abs(self.state.broker_leader_count_cv - 1.0690) < 1e-4
+
     def test_weighted_topic_broker_imbalance(self):
         """Test that weighted_topic_broker_imbalance returns the correct value
         for the default assignment.
@@ -447,6 +459,7 @@ class Test_State(object):
         assert new_state.broker_partition_counts == (4, 5, 5, 3, 2)
         assert new_state.broker_weights == (24, 26, 23, 12, 12)
         assert new_state.broker_leader_weights == (24, 2, 9, 0, 0)
+        assert new_state.broker_leader_counts == (4, 1, 2, 0, 0)
         assert new_state.topic_broker_count == (
             (0, 1, 2, 1, 0),
             (2, 2, 1, 2, 1),
@@ -485,6 +498,7 @@ class Test_State(object):
         assert new_state.broker_partition_counts == (4, 5, 5, 4, 1)
         assert new_state.broker_weights == (24, 26, 21, 18, 8)
         assert new_state.broker_leader_weights == (24, 2, 3, 6, 0)
+        assert new_state.broker_leader_counts == (4, 1, 1, 1, 0)
         assert new_state.topic_broker_count == (
             (0, 1, 2, 1, 0),
             (2, 2, 2, 2, 0),
@@ -524,6 +538,7 @@ class Test_State(object):
         assert new_state.broker_partition_counts == (3, 4, 5, 4, 3)
         assert new_state.broker_weights == (16, 21, 24, 20, 16)
         assert new_state.broker_leader_weights == (16, 2, 6, 8, 3)
+        assert new_state.broker_leader_counts == (3, 1, 1, 1, 1)
         assert new_state.topic_broker_count == (
             (0, 1, 1, 1, 1),
             (2, 1, 2, 2, 1),
@@ -560,6 +575,7 @@ class Test_State(object):
             (0, 1, 4),
         )
         assert new_state.broker_partition_counts == (4, 5, 6, 3, 1)
+        assert new_state.broker_leader_counts == (3, 1, 3, 0, 0)
         assert new_state.broker_leader_weights == (19, 2, 14, 0, 0)
         assert abs(new_state.broker_leader_weight_cv - 1.1357) < 1e-4
         assert new_state.rg_replicas == (
@@ -589,6 +605,7 @@ class Test_State(object):
         assert new_state.broker_partition_counts == (4, 5, 6, 3, 2)
         assert new_state.broker_weights == (24, 26, 27, 12, 14)
         assert new_state.broker_leader_weights == (24, 2, 9, 0, 0)
+        assert new_state.broker_leader_counts == (4, 1, 2, 0, 0)
         assert new_state.topic_broker_count == (
             (0, 1, 2, 1, 0),
             (2, 2, 2, 2, 0),
@@ -627,6 +644,7 @@ class Test_State(object):
         assert new_state.broker_partition_counts == (4, 5, 5, 3, 1)
         assert new_state.broker_weights == (24, 26, 20, 12, 8)
         assert new_state.broker_leader_weights == (24, 2, 9, 0, 0)
+        assert new_state.broker_leader_counts == (4, 1, 2, 0, 0)
         assert new_state.topic_broker_count == (
             (0, 1, 2, 1, 0),
             (2, 2, 2, 2, 0),

--- a/tests/kafka_cluster_manager/stats_test.py
+++ b/tests/kafka_cluster_manager/stats_test.py
@@ -28,8 +28,8 @@ def test_variance():
     assert stats.variance([1, 2, 3, 4, 5]) == 2
 
 
-def test_standard_deviation_p():
-    assert stats.standard_deviation_p([1, 2, 3, 4, 5]) == sqrt(2)
+def test_stdevp():
+    assert stats.stdevp([1, 2, 3, 4, 5]) == sqrt(2)
 
 
 def test_coefficient_of_variation():

--- a/tests/kafka_cluster_manager/stats_test.py
+++ b/tests/kafka_cluster_manager/stats_test.py
@@ -28,8 +28,8 @@ def test_variance():
     assert stats.variance([1, 2, 3, 4, 5]) == 2
 
 
-def test_standard_deviation():
-    assert stats.standard_deviation([1, 2, 3, 4, 5]) == sqrt(2)
+def test_standard_deviation_p():
+    assert stats.standard_deviation_p([1, 2, 3, 4, 5]) == sqrt(2)
 
 
 def test_coefficient_of_variation():


### PR DESCRIPTION
Consider the partition count CV when computing the final score. This change introduces a new criteria when rebalancing.

If the cluster is already balanced by only broker weight, the movement of the smallest partitions (smaller impact on broker weight) is implicitly preferred to improve the partition count criteria.
In clusters with lots of empty partitions this change improves the overall utilization.
 
Internal ticket KAFKA-5777