### PR TITLE
KAFKA-1497 - Remove docker network after acceptance tests

### DIFF
--- a/docker/itest_0.10.1.1/download-kafka.sh
+++ b/docker/itest_0.10.1.1/download-kafka.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 
-mirror=$(curl --stderr /dev/null https://www.apache.org/dyn/closer.cgi\?as_json\=1 | jq -r '.preferred')
-url="${mirror}kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
+url="https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
 wget -q "${url}" -O "/tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"

--- a/docker/itest_0.8.2/download-kafka.sh
+++ b/docker/itest_0.8.2/download-kafka.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 
-mirror=$(curl --stderr /dev/null https://www.apache.org/dyn/closer.cgi\?as_json\=1 | jq -r '.preferred')
-url="${mirror}kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
+url="https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
 wget -q "${url}" -O "/tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"

--- a/docker/itest_0.9.0/download-kafka.sh
+++ b/docker/itest_0.9.0/download-kafka.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 
-mirror=$(curl --stderr /dev/null https://www.apache.org/dyn/closer.cgi\?as_json\=1 | jq -r '.preferred')
-url="${mirror}kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
+url="https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
 wget -q "${url}" -O "/tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"

--- a/docker/kafka_0.10.1.1/download-kafka.sh
+++ b/docker/kafka_0.10.1.1/download-kafka.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 
-mirror=$(curl --stderr /dev/null https://www.apache.org/dyn/closer.cgi\?as_json\=1 | jq -r '.preferred')
-url="${mirror}kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
+url="https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
 wget -q "${url}" -O "/tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"

--- a/docker/kafka_0.8.2/download-kafka.sh
+++ b/docker/kafka_0.8.2/download-kafka.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 
-mirror=$(curl --stderr /dev/null https://www.apache.org/dyn/closer.cgi\?as_json\=1 | jq -r '.preferred')
-url="${mirror}kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
+url="https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
 wget -q "${url}" -O "/tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"

--- a/docker/kafka_0.9.0/download-kafka.sh
+++ b/docker/kafka_0.9.0/download-kafka.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 url="https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
-wget  "${url}" -O "/tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
+wget -q "${url}" -O "/tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"

--- a/docker/kafka_0.9.0/download-kafka.sh
+++ b/docker/kafka_0.9.0/download-kafka.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 
-mirror=$(curl --stderr /dev/null https://www.apache.org/dyn/closer.cgi\?as_json\=1 | jq -r '.preferred')
-url="${mirror}kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
-wget -q "${url}" -O "/tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
+url="https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
+wget  "${url}" -O "/tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"

--- a/kafka_utils/kafka_consumer_manager/commands/offset_get.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_get.py
@@ -170,7 +170,7 @@ class OffsetGet(OffsetManagerBase):
             return get_consumer_offsets_metadata(
                 client, group, topics_dict, False, storage,
             )
-        except:
+        except Exception:
             print(
                 "Error: Encountered error with Kafka, please try again later.",
                 file=sys.stderr

--- a/kafka_utils/kafka_consumer_manager/commands/rename_group.py
+++ b/kafka_utils/kafka_consumer_manager/commands/rename_group.py
@@ -155,7 +155,7 @@ class RenameGroup(OffsetManagerBase):
                     groupid=old_groupid,
                 )
                 zk.delete(old_base_path, recursive=True)
-            except:
+            except Exception:
                 print(
                     "Error: Unable to migrate all metadata in Zookeeper. "
                     "Please re-run the command.",

--- a/kafka_utils/util/__init__.py
+++ b/kafka_utils/util/__init__.py
@@ -28,10 +28,10 @@ def tuple_replace(tup, *pairs):
     :param pairs: Any number of (index, value) tuples where index is the index
         of the item to replace and value is the new value of the item.
     """
-    l = list(tup)
+    tuple_list = list(tup)
     for index, value in pairs:
-        l[index] = value
-    return tuple(l)
+        tuple_list[index] = value
+    return tuple(tuple_list)
 
 
 def tuple_alter(tup, *pairs):
@@ -42,10 +42,10 @@ def tuple_alter(tup, *pairs):
         of the item to alter and the new value is func(tup[index]).
     """
     # timeit says that this is faster than a similar
-    l = list(tup)
+    tuple_list = list(tup)
     for i, f in pairs:
-        l[i] = f(l[i])
-    return tuple(l)
+        tuple_list[i] = f(tuple_list[i])
+    return tuple(tuple_list)
 
 
 def tuple_remove(tup, *items):
@@ -55,10 +55,10 @@ def tuple_remove(tup, *items):
     :param items: Any number of items. The first instance of each item will
         be removed from the tuple.
     """
-    l = list(tup)
+    tuple_list = list(tup)
     for item in items:
-        l.remove(item)
-    return tuple(l)
+        tuple_list.remove(item)
+    return tuple(tuple_list)
 
 
 def positive_int(string):

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,9 @@ commands =
     dockeritest:     -e ITEST_PYTHON_FACTOR={env:ITEST_PYTHON_FACTOR} \
     dockeritest:     -e ACCEPTANCE_TAGS={env:ACCEPTANCE_TAGS} \
     dockeritest:     itest /scripts/run_tests.sh; exit_status=$?; \
-    dockeritest:   docker-compose stop; exit $exit_status"
+    dockeritest:   docker-compose stop; \
+    dockeritest:   docker network rm kafkautils_default; \
+    dockeritest:   exit $exit_status"
 
 [testenv:coverage]
 deps =


### PR DESCRIPTION
This change will configure tox to remove the docker network after every acceptance test, cleaning up the environment.