### PR TITLE
Improve rolling restart

### DIFF
--- a/kafka_utils/kafka_rolling_restart/main.py
+++ b/kafka_utils/kafka_rolling_restart/main.py
@@ -330,7 +330,7 @@ def wait_for_broker_shutdown(host, jolokia_port, jolokia_prefix, stop_check_inte
             print("Broker is stopped")
             return
         else:
-            print("Broker is in state {state}... ({i}/{limit}".format(state=broker_state, i=i, limit=max_checks))
+            print("Broker is in state {state}... ({i}/{limit})".format(state=broker_state, i=i, limit=max_checks))
         if i >= max_checks:
             raise WaitTimeoutException()
         time.sleep(stop_check_interval)

--- a/kafka_utils/kafka_rolling_restart/main.py
+++ b/kafka_utils/kafka_rolling_restart/main.py
@@ -316,7 +316,7 @@ def read_broker_state(host, jolokia_port, jolokia_prefix):
         print("Broker {0} is down: {1}.".format(host, e), file=sys.stderr)
         broker_state = 0
     except KeyError:
-        print("Cannot find the key, Kafka is probably still starting up", file=sys.stderr)
+        print("Cannot find the key, Kafka is probably starting up or shutting down", file=sys.stderr)
         broker_state = 1
     return broker_state, broker_state_strings[broker_state]
 

--- a/kafka_utils/kafka_rolling_restart/main.py
+++ b/kafka_utils/kafka_rolling_restart/main.py
@@ -577,8 +577,8 @@ def run():
                 opts.stop_check_time_limit
             )
         except TaskFailedException:
-            print("ERROR: pre/post tasks failed, exiting")
+            print("ERROR: pre/post tasks failed, exiting: {e}".format(e=repr(e)))
             sys.exit(1)
         except WaitTimeoutException:
-            print("ERROR: cluster is still unhealthy, exiting")
+            print("ERROR: cluster is still unhealthy, exiting: {e}".format(e=repr(e)))
             sys.exit(1)

--- a/kafka_utils/kafka_rolling_restart/main.py
+++ b/kafka_utils/kafka_rolling_restart/main.py
@@ -295,7 +295,8 @@ def read_broker_state(host, jolokia_port, jolokia_prefix):
                             2: "RecoveringFromUncleanShutdown",
                             3: "RunningAsBroker",
                             6: "PendingControlledShutdown",
-                            7: "BrokerShuttingDown"}
+                            7: "BrokerShuttingDown",
+                            -1: "Unavailable"}  # Added for when Jolokia is connecting, but not returning values
     broker_state = 0   # Assume not running unless we get a state
     session = FuturesSession()
     url = "http://{host}:{port}/{prefix}/read/{key}".format(
@@ -317,7 +318,7 @@ def read_broker_state(host, jolokia_port, jolokia_prefix):
         broker_state = 0
     except KeyError:
         print("Cannot find the key, Kafka is probably starting up or shutting down", file=sys.stderr)
-        broker_state = 1
+        broker_state = -1
     return broker_state, broker_state_strings[broker_state]
 
 

--- a/kafka_utils/kafka_rolling_restart/main.py
+++ b/kafka_utils/kafka_rolling_restart/main.py
@@ -335,7 +335,8 @@ def wait_for_broker_shutdown(host, jolokia_port, jolokia_prefix, stop_check_inte
         else:
             print("Broker is in state {state}... ({i}/{limit})".format(state=broker_state, i=i, limit=max_checks))
         if i >= max_checks:
-            raise WaitTimeoutException()
+            raise WaitTimeoutException('Exceeded stop_check_time_limit while waiting for broker to shut down. '
+                                       'You will need to manually restart the broker at {host}'.format(host=host))
 
 
 def wait_for_stable_cluster(
@@ -422,6 +423,8 @@ def execute_rolling_restart(
     when all the brokers are answering and are reporting zero under replicated
     partitions.
 
+    :param stop_check_time_limit: max number of seconds to wait for clean broker shutdown before failing
+    :param stop_check_interval: number of seconds between each check for broker shutdown
     :param brokers: the brokers that will be restarted
     :type brokers: map of broker ids and host names
     :param jolokia_port: HTTP port for Jolokia

--- a/kafka_utils/kafka_rolling_restart/main.py
+++ b/kafka_utils/kafka_rolling_restart/main.py
@@ -317,7 +317,7 @@ def read_broker_state(host, jolokia_port, jolokia_prefix):
         print("Broker {0} is down: {1}.".format(host, e), file=sys.stderr)
         broker_state = 0
     except KeyError:
-        print("Cannot find the key, Kafka is probably starting up or shutting down", file=sys.stderr)
+        print("Cannot find the JMX key, Kafka is probably starting up or shutting down", file=sys.stderr)
         broker_state = -1
     return broker_state, broker_state_strings[broker_state]
 

--- a/kafka_utils/kafka_rolling_restart/main.py
+++ b/kafka_utils/kafka_rolling_restart/main.py
@@ -466,8 +466,8 @@ def execute_rolling_restart(
             )
             print("Stopping {0} ({1}/{2})".format(host, n + 1, len(all_hosts) - skip))
             stop_broker(host, connection, stop_command, verbose)
-            execute_task(post_stop_task, host)
             wait_for_broker_shutdown(host, jolokia_port, jolokia_prefix, stop_check_interval, stop_check_time_limit)
+            execute_task(post_stop_task, host)
         # we open a new SSH connection in case the hostname has a new IP
         with ssh(host=host, forward_agent=True, sudoable=True, max_attempts=3, max_timeout=2) as connection:
             print("Starting {0} ({1}/{2})".format(host, n + 1, len(all_hosts) - skip))


### PR DESCRIPTION
Added checks after broker stop to read BrokerState mbean from jolokia before starting the broker back up. While this could be implemented as a post-stop-task, I feel that this behavior is necessary to help the tool be more generic. The default behavior does not work for non-blocking init scripts as a clean broker shutdown takes time, resulting in the rolling restart tool failing, as it tries to start the broker back up immediately after shutdown, which fails and leaves a broker down. 

This is how I made the changes to work in our environment, but some things might need to be changed or reordered to fit better into the tool generically. Open to any and all suggestions.