### PR TITLE
List unavailable brokers in case replicas are unavailable

### DIFF
--- a/kafka_utils/kafka_check/commands/replica_unavailability.py
+++ b/kafka_utils/kafka_check/commands/replica_unavailability.py
@@ -34,17 +34,23 @@ class ReplicaUnavailabilityCmd(KafkaCheckCmd):
     def run_command(self):
         """replica_unavailability command, checks number of replicas not available
         for communication over all brokers in the Kafka cluster."""
-        replica_unavailability = get_topic_partition_with_error(
+        fetch_unavailable_brokers = True
+        result = get_topic_partition_with_error(
             self.cluster_config,
             REPLICA_NOT_AVAILABLE_ERROR,
+            fetch_unavailable_brokers=fetch_unavailable_brokers,
         )
+        if fetch_unavailable_brokers:
+            replica_unavailability, unavailable_brokers = result
+        else:
+            replica_unavailability = result
 
         errcode = status_code.OK if not replica_unavailability else status_code.CRITICAL
-        out = _prepare_output(replica_unavailability, self.args.verbose)
+        out = _prepare_output(replica_unavailability, unavailable_brokers, self.args.verbose)
         return errcode, out
 
 
-def _prepare_output(partitions, verbose):
+def _prepare_output(partitions, unavailable_brokers, verbose):
     """Returns dict with 'raw' and 'message' keys filled."""
     partitions_count = len(partitions)
     out = {}
@@ -55,8 +61,10 @@ def _prepare_output(partitions, verbose):
     if partitions_count == 0:
         out['message'] = 'All replicas available for communication.'
     else:
-        out['message'] = "{replica_unavailability} replicas unavailable for communication.".format(
+        out['message'] = "{replica_unavailability} replicas unavailable for communication. " \
+            "Unavailable Brokers: {unavailable_brokers}".format(
             replica_unavailability=partitions_count,
+            unavailable_brokers=', '.join([str(e) for e in unavailable_brokers]),
         )
         if verbose:
             lines = (

--- a/kafka_utils/util/metadata.py
+++ b/kafka_utils/util/metadata.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 from kafka.structs import PartitionMetadata
 
 from kafka_utils.util.client import KafkaToolClient
+from kafka_utils.util.zookeeper import ZK
 
 
 LEADER_NOT_AVAILABLE_ERROR = 5
@@ -42,16 +43,27 @@ def get_topic_partition_metadata(hosts):
     return topic_partitions
 
 
-def get_topic_partition_with_error(cluster_config, error):
+def get_topic_partition_with_error(cluster_config, error, fetch_unavailable_brokers=False):
     """Fetches the metadata from the cluster and returns the set of
     (topic, partition) tuples containing all the topic-partitions
-    currently affected by the specified error"""
+    currently affected by the specified error. It also fetches unavailable-broker list
+    if required."""
 
     metadata = get_topic_partition_metadata(cluster_config.broker_list)
     affected_partitions = set()
+    if fetch_unavailable_brokers:
+        unavailable_brokers = set([])
     for partitions in metadata.values():
         for partition_metadata in partitions.values():
             if int(partition_metadata.error) == error:
+                if fetch_unavailable_brokers:
+                    with ZK(cluster_config) as zk:
+                        topic_data = zk.get_topics(partition_metadata.topic)
+                        unavailable_brokers = unavailable_brokers.union(set(topic_data[partition_metadata.topic]['partitions']
+                                                                            [str(partition_metadata.partition)]['replicas']) - set(partition_metadata.replicas))
                 affected_partitions.add((partition_metadata.topic, partition_metadata.partition))
 
-    return affected_partitions
+    if fetch_unavailable_brokers:
+        return affected_partitions, unavailable_brokers
+    else:
+        return affected_partitions

--- a/kafka_utils/util/metadata.py
+++ b/kafka_utils/util/metadata.py
@@ -60,7 +60,7 @@ def get_topic_partition_with_error(cluster_config, error, fetch_unavailable_brok
     metadata = get_topic_partition_metadata(cluster_config.broker_list)
     affected_partitions = set()
     if fetch_unavailable_brokers:
-        unavailable_brokers = set([])
+        unavailable_brokers = set()
     with ZK(cluster_config) as zk:
         for partitions in metadata.values():
             for partition_metadata in partitions.values():

--- a/tests/util/metadata_test.py
+++ b/tests/util/metadata_test.py
@@ -117,7 +117,10 @@ class TestMetadata(object):
     def test_get_topic_partition_metadata_empty(self, mock_get_metadata):
         mock_get_metadata.return_value = {}
 
-        actual = get_topic_partition_with_error(self.cluster_config, 5)
+        with mock.patch(
+            'kafka_utils.util.metadata.ZK',
+        ):
+            actual = get_topic_partition_with_error(self.cluster_config, 5)
         expected = set([])
         assert actual == expected
         mock_get_metadata.asserd_called_wity('some_list')
@@ -125,20 +128,29 @@ class TestMetadata(object):
     def test_get_topic_partition_metadata_no_errors(self, mock_get_metadata):
         mock_get_metadata.return_value = METADATA_RESPONSE_ALL_FINE
 
-        actual = get_topic_partition_with_error(self.cluster_config, 5)
+        with mock.patch(
+            'kafka_utils.util.metadata.ZK',
+        ):
+            actual = get_topic_partition_with_error(self.cluster_config, 5)
         expected = set([])
         assert actual == expected
 
     def test_get_topic_partition_metadata_replica_not_available(self, mock_get_metadata):
         mock_get_metadata.return_value = METADATA_RESPONSE_WITH_ERRORS
 
-        actual = get_topic_partition_with_error(self.cluster_config, REPLICA_NOT_AVAILABLE_ERROR)
-        expected = set([('topic0', 0), ('topic1', 1)])
+        with mock.patch(
+            'kafka_utils.util.metadata.ZK',
+        ):
+            actual = get_topic_partition_with_error(self.cluster_config, REPLICA_NOT_AVAILABLE_ERROR)
+        expected = {('topic0', 0), ('topic1', 1)}
         assert actual == expected
 
     def test_get_topic_partition_metadata_leader_not_available(self, mock_get_metadata):
         mock_get_metadata.return_value = METADATA_RESPONSE_WITH_ERRORS
 
-        actual = get_topic_partition_with_error(self.cluster_config, LEADER_NOT_AVAILABLE_ERROR)
+        with mock.patch(
+            'kafka_utils.util.metadata.ZK',
+        ):
+            actual = get_topic_partition_with_error(self.cluster_config, LEADER_NOT_AVAILABLE_ERROR)
         expected = set([('topic0', 1)])
         assert actual == expected


### PR DESCRIPTION
This change checks the list of replicas from zookeeper, and compare it with partition-metadata when error 9 (REPLICA_NOT_AVAILABLE_ERROR) is encountered, to get the list of unavailable brokers.