### PR TITLE
Add --topics option to kafka_consumer_manager unsuscribe_topics cmd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ pip-delete-this-directory.txt
 .cache
 nosetests.xml
 coverage.xml
+.pytest_cache/
 
 # Sphinx documentation
 docs/_build/


### PR DESCRIPTION
The unsuscribe_topics command of kafka_consumer_manager is now able to
unsuscribe only a subset of topics among all the ones consumed by the
consumer group. The --topics is mutually exclusive with the --topic
option and consequently with --partitions.

This is my first PR for this project, so please let me know whether I have to call in more reviewers and/or how to test my change manually (for now I only relied on unit tests).