### PR TITLE
Handle missing topics in `/config/topics` ZK path

### DIFF
--- a/kafka_utils/util/zookeeper.py
+++ b/kafka_utils/util/zookeeper.py
@@ -121,7 +121,7 @@ class ZK:
             )
         except NoNodeError as e:
 
-            # Kafka version before 0.9.0 does not have "/config/topics/<topic_name>" path in ZK and
+            # Kafka version before 0.8.1 does not have "/config/topics/<topic_name>" path in ZK and
             # if the topic exists, return default dict instead of raising an Exception.
             # Ref: https://cwiki.apache.org/confluence/display/KAFKA/Kafka+data+structures+in+Zookeeper.
 


### PR DESCRIPTION
If a legitimate topic name is missing in the `/config/topics` path, it should return a default/empty dict rather than raising an exception which should occur only if the topic is non-existent. The topic can be missing in the config path if it is created Kafka version prior to 0.8.1.