### PR TITLE
Fix delete_group for zookeeper, make offset_get description more accu…

### DIFF
--- a/kafka_utils/kafka_consumer_manager/commands/offset_manager.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_manager.py
@@ -147,14 +147,22 @@ class OffsetManagerBase(object):
             try:
                 topics = zk.get_my_subscribed_topics(groupid)
             except NoNodeError:
-                if fail_on_error:
+                if groupid in zk.get_children("/consumers"):
                     print(
-                        "Error: Consumer Group ID {groupid} does not exist.".format(
+                        "Error: Offsets for Consumer Group ID {groupid} not found.".format(
                             groupid=groupid
                         ),
-                        file=sys.stderr
+                        file=sys.stderr,
                     )
-                    sys.exit(1)
+                else:
+                    if fail_on_error:
+                        print(
+                            "Error: Consumer Group ID {groupid} does not exist.".format(
+                                groupid=groupid
+                            ),
+                            file=sys.stderr,
+                        )
+                        sys.exit(1)
         return topics
 
 


### PR DESCRIPTION
For kafka-consumer-manager command, when there exists the directory consumers/{consumer group id} but not consumers/{consumer group id}/offsets in the zookeeper:

Fix the offset_get sub command saying consumer group does not exist issue.

Fix the delete_group sub command saying the consumer group does not exist issue , the expected behavior should be delete the group.