### PR TITLE
Improve performance of broker decommission process

### DIFF
--- a/kafka_utils/kafka_cluster_manager/cluster_info/cluster_topology.py
+++ b/kafka_utils/kafka_cluster_manager/cluster_info/cluster_topology.py
@@ -205,6 +205,11 @@ class ClusterTopology(object):
                     partition = self.partitions[partition_name]
                     old_replicas = [broker for broker in partition.replicas]
 
+                    # No change needed. Save ourself some CPU time.
+                    # Replica order matters as the first one is the leader.
+                    if new_replicas == old_replicas:
+                        continue
+
                     # Remove old partitions from broker
                     # This also updates partition replicas
                     for broker in old_replicas:

--- a/tests/kafka_cluster_manager/genetic_balancer_test.py
+++ b/tests/kafka_cluster_manager/genetic_balancer_test.py
@@ -410,6 +410,17 @@ class Test_State(object):
         """Test that the state assignment matches the default_assignment."""
         assert self.state.assignment == default_assignment
 
+    def test_empty_pending_assignment(self):
+        """Test that pending assignment is emptyy when no change occured."""
+        assert self.state.pending_assignment == {}
+
+    def test_pending_assignment(self):
+        new_state = self.state.add_replica(4, 4)
+
+        assert new_state.pending_assignment == {
+            (u'T2', 0): ['2', '4']
+        }
+
     def test_broker_partition_count_cv(self):
         """Test that broker_partition_count_cv returns the correct value for the
         default assignment.

--- a/tests/util/zookeeper_test.py
+++ b/tests/util/zookeeper_test.py
@@ -23,7 +23,7 @@ from kafka_utils.util.serialization import dump_json
 from kafka_utils.util.zookeeper import ZK
 
 
-TestGetTopics = namedtuple('TestGetTopics', ['ctime'])
+MockGetTopics = namedtuple('MockGetTopics', ['ctime'])
 
 
 @mock.patch(
@@ -265,7 +265,7 @@ class TestZK(object):
                 return_value=(
                     (
                         b'{"version": "1", "partitions": {"0": [1, 0]}}',
-                        TestGetTopics(31000),
+                        MockGetTopics(31000),
                     )
                 )
             )
@@ -274,7 +274,7 @@ class TestZK(object):
                 return_value=(
                     (
                         b'{"version": "2"}',
-                        TestGetTopics(32000),
+                        MockGetTopics(32000),
                     )
                 )
             )
@@ -296,7 +296,7 @@ class TestZK(object):
             assert actual_with_fetch_state == expected_with_fetch_state
 
             zk._fetch_partition_info = mock.Mock(
-                return_value=TestGetTopics(33000)
+                return_value=MockGetTopics(33000)
             )
 
             actual_without_fetch_state = zk.get_topics("some_topic", fetch_partition_state=False)


### PR DESCRIPTION
## Description

(I'm currently only focusing on the decommissioning process. In order to keep the review process smooth, I'll start adding changes for rebalance and other commands once this PR is merged.)

    Generating a `_State` is an intensive task. Instead of generating a new
    `_State` after each new replica assignement, use the one that just got
    applied.
 

    Generating a full cluster assignment for a `_State` is an intensive
    task. Instead, only generate an assignment containing incremental
    changes incurred by the state changes.
 

    Finding the index of an element in a tuple multiple times is an
    intensive task. Instead, generate index reverse lookup maps once and use
    it each time.
 

    Make the decommission process repeatable by adding partitions in
    lexicographic order. This makes the verification easier. :-)

## Testing

* Basic unit tests + existing test suite are all green.
* Manually tested on our dev cluster. Output between the status quo and the new branch are the same.

## Performance

First results seems to indicate a 500x speed-up on the CPU-intensive part (excluding ZK+Metrics computation), from 125 minutes to 15 seconds 😄  (Using cProfile, which itself might have added a slight overhead)

(master)
<img width="1438" alt="screen shot 2018-05-23 at 3 42 04 pm" src="https://user-images.githubusercontent.com/4570851/40431776-03a465e6-5ea0-11e8-8775-784e8b276439.png">

(u/flavr/KAFKA-9310-faster-decomission)
<img width="1436" alt="screen shot 2018-05-23 at 3 42 15 pm" src="https://user-images.githubusercontent.com/4570851/40431777-03bce4cc-5ea0-11e8-883d-fd5271259484.png">

Commands used to run the test: (spoiler alert: they are the same 😉)

(master)
```
time sudo -u root /opt/venvs/yelp-kafka-tool/bin/python -m cProfile -o output.prof /usr/bin/kafka-cluster-manager --cluster-type scribe     --cluster-name uswest1-devc     --logconf /nail/etc/kafka/conditional_rebalance_log.ini     --genetic-balancer     --partition-measurer yelp_kafka_tool.partition_measurement.pickled_signalfx_partition_measurer     --measurer-args ' --bytes-in-weight 0.25 --bytes-out-weight 0.25 --messages-in-weight 0.25 --partition-size-weight 0.25'     decommission 170396394     --max-partition-movements 250     --max-leader-changes 250
```

(u/flavr/KAFKA-9310-faster-decomission)
```
time sudo -u root /opt/venvs/yelp-kafka-tool/bin/python -m cProfile -o output.prof /usr/bin/kafka-cluster-manager --cluster-type scribe     --cluster-name uswest1-devc     --logconf /nail/etc/kafka/conditional_rebalance_log.ini     --genetic-balancer     --partition-measurer yelp_kafka_tool.partition_measurement.pickled_signalfx_partition_measurer     --measurer-args ' --bytes-in-weight 0.25 --bytes-out-weight 0.25 --messages-in-weight 0.25 --partition-size-weight 0.25'     decommission 170396394     --max-partition-movements 250     --max-leader-changes 250
```