### PR TITLE
Show error message for nonexistent group in offset_get

### DIFF
--- a/kafka_utils/kafka_consumer_manager/commands/offset_manager.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_manager.py
@@ -131,7 +131,15 @@ class OffsetManagerBase(object):
             groupid
     ):
         kafka_group_reader = KafkaGroupReader(cluster_config)
-        return kafka_group_reader.read_group(groupid)
+        group_topics = kafka_group_reader.read_group(groupid)
+        if len(group_topics) == 0:
+            print(
+                "Error: Either Consumer Group {groupid} has never committed offsets, or the group does not exist.".format(
+                    groupid=groupid,
+                ),
+                file=sys.stderr,
+            )
+        return group_topics
 
     @classmethod
     def get_topics_for_group_from_zookeeper(


### PR DESCRIPTION
We generate the list of groups in `list_groups` command by calling `kafka_group_reader.read_groups().keys()`; so if a group is not in this list, it doesn't exist.

`kafka_group_reader.read_group()` is just a wrapper around the `read_groups()` method that gets the specific `group_id` entry from all of the groups (i.e., `read_groups().get(group_id, [])`. So if there are no topics for the group (`group_topics == []`) the group does not exist