### PR TITLE
KAFKA-13478: Remove cryptography dependency.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,9 @@
+flake8
 ipdb==0.10.3
 ipython==4.2.0
 ipython-genutils==0.1.0
+mock
 pre-commit==0.8.0
+pytest
+setuptools==30.0.0
 tox-pip-extensions==1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ PyYAML==3.11
 argcomplete==0.8.1
 boto==2.38.0
 cffi==1.1.2
-cryptography==1.8.1
 ecdsa==0.11
 enum34==1.1.6
 futures==3.0.1
@@ -15,7 +14,6 @@ paramiko==1.16.0
 pyOpenSSL==0.15.1
 pyasn1==0.1.7
 pycparser==2.10
-pycrypto==2.6.1
 requests==2.7.0
 requests-futures==0.9.5
 retrying==1.3.3

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
         "scripts/kafka-corruption-check",
     ],
     install_requires=[
-        "cryptography>=1.8.1,<2.0.0",
         "kafka-python>=1.3.2,<1.5.0",
         "kazoo>=2.0,<3.0.0",
         "PyYAML<4.0.0",

--- a/tox.ini
+++ b/tox.ini
@@ -13,9 +13,6 @@ python =
 [testenv]
 deps =
     -rrequirements-dev.txt
-    flake8
-    pytest
-    mock
     dockeritest: docker-compose==1.7.0
 whitelist_externals = /bin/bash
 passenv = ITEST_PYTHON_FACTOR KAFKA_VERSION ACCEPTANCE_TAGS


### PR DESCRIPTION
Remove the cryptography dependency.

This also fixes the problem where "make test" fails locally on yelp dev boxes.