### PR TITLE
Fix bug in unsubscribe_topics with --topics flag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+1.7.1 (September 7, 2018)
+----------------------------
+* Fix bug in unsubscribe_topics command where all subscribed topics were being
+  displayed as subject to change regardless of specified --topics
+
 1.7.0 (September 6, 2018)
 ----------------------------
 * Add new commands offset_set_timestamp and offsets_for_timestamp

--- a/kafka_utils/__init__.py
+++ b/kafka_utils/__init__.py
@@ -12,4 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '1.7.0'
+__version__ = '1.7.1'

--- a/kafka_utils/kafka_consumer_manager/commands/unsubscribe_topics.py
+++ b/kafka_utils/kafka_consumer_manager/commands/unsubscribe_topics.py
@@ -78,21 +78,6 @@ class UnsubscribeTopics(OffsetWriter):
         client = KafkaToolClient(cluster_config.broker_list)
         client.load_metadata_for_topics()
 
-        if args.topic and args.topics:
-            print(
-                "Error: Cannot specify --topic and --topics at the same time.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-
-        if args.partitions and args.topics:
-            print(
-                "Error: Cannot use --partitions with --topics. Use --topic "
-                "instead.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-
         # if topic is not None topics_dict will contain only info about that
         # topic, otherwise it will contain info about all topics for the group
         topics_dict = cls.preprocess_args(
@@ -102,17 +87,10 @@ class UnsubscribeTopics(OffsetWriter):
             cluster_config,
             client,
             storage=args.storage,
+            topics=args.topics,
         )
 
         topics = args.topics if args.topics else ([args.topic] if args.topic else [])
-        for topic in topics:
-            if topic not in topics_dict:
-                print(
-                    "Error: Consumer {groupid} is not subscribed to topic:"
-                    " {topic}.".format(groupid=args.groupid, topic=topic),
-                    file=sys.stderr,
-                )
-                sys.exit(1)
 
         with ZK(cluster_config) as zk:
             if args.storage == 'zookeeper':

--- a/tests/kafka_consumer_manager/test_offset_manager.py
+++ b/tests/kafka_consumer_manager/test_offset_manager.py
@@ -158,3 +158,93 @@ class TestOffsetManagerBase(object):
                 mock_kafka_client
             )
             assert mock_exit.called
+
+    def test_preprocess_args_topic_and_topics(self, mock_kafka_client):
+        args = mock.Mock(
+            groupid="some_group",
+            topic="topic1",
+            partitions=[0, 1, 2],
+            topics=["topic1", "topic2"],
+        )
+
+        with self.mock_get_topics(), mock.patch.object(
+            sys,
+            "exit",
+            autospec=True,
+        ) as mock_exit:
+            OffsetManagerBase.preprocess_args(
+                args.groupid,
+                args.topic,
+                args.partitions,
+                mock.Mock(),
+                mock_kafka_client,
+                topics=args.topics,
+            )
+            assert mock_exit.called
+
+    def test_preprocess_args_topics_and_partitions(self, mock_kafka_client):
+        args = mock.Mock(
+            groupid="some_group",
+            partitions=[0, 1, 2],
+            topics=["topic1", "topic2"],
+        )
+
+        with self.mock_get_topics(), mock.patch.object(
+            sys,
+            "exit",
+            autospec=True,
+        ) as mock_exit:
+            OffsetManagerBase.preprocess_args(
+                args.groupid,
+                args.topic,
+                args.partitions,
+                mock.Mock(),
+                mock_kafka_client,
+                topics=args.topics,
+            )
+            assert mock_exit.called
+
+    def test_preprocess_args_missing_topic(self, mock_kafka_client):
+        args = mock.Mock(
+            groupid="some_group",
+            topic=None,
+            partitions=None,
+            topics=["topic1", "memes"],
+        )
+
+        with self.mock_get_topics(), mock.patch.object(
+            sys,
+            "exit",
+            autospec=True,
+        ) as mock_exit:
+            OffsetManagerBase.preprocess_args(
+                args.groupid,
+                args.topic,
+                args.partitions,
+                mock.Mock(),
+                mock_kafka_client,
+                topics=args.topics,
+            )
+            assert mock_exit.called
+
+    def test_preprocess_args_topics(self, mock_kafka_client):
+        args = mock.Mock(
+            topic=None,
+            partitions=None,
+            groupid="some_group",
+            topics=["topic1", "topic2"],
+        )
+
+        expected_topics_dict = {"topic1": [0, 1, 2], "topic2": [0, 1, 2, 3]}
+
+        with self.mock_get_topics() as mock_get_topics:
+            topics_dict = OffsetManagerBase.preprocess_args(
+                args.groupid,
+                args.topic,
+                args.partitions,
+                mock.Mock(),
+                mock_kafka_client,
+                topics=args.topics,
+            )
+            assert mock_get_topics.called
+            assert topics_dict == expected_topics_dict

--- a/tests/kafka_consumer_manager/test_unsubscribe_topics.py
+++ b/tests/kafka_consumer_manager/test_unsubscribe_topics.py
@@ -107,30 +107,6 @@ class TestUnsubscribeTopics(object):
             assert zk_obj.unsubscribe_topics.call_count == 0
             assert kafka_obj.unsubscribe_topics.call_count == 1
 
-    def test_run_unsubscribe_both_topic_and_topics(self, client, zk, zk_unsubscriber, kafka_unsubscriber):
-        with mock.patch.object(
-                UnsubscribeTopics,
-                'preprocess_args',
-                spec=UnsubscribeTopics.preprocess_args,
-                return_value=self.topics_partitions,
-        ):
-            args = mock.Mock(topics=["foo", "bar", "baz"], topic="quax", partitions=None)
-
-            with pytest.raises(SystemExit):
-                UnsubscribeTopics.run(args, self.cluster_config)
-
-    def test_run_unsubscribe_both_partitions_and_topics(self, client, zk, zk_unsubscriber, kafka_unsubscriber):
-        with mock.patch.object(
-                UnsubscribeTopics,
-                'preprocess_args',
-                spec=UnsubscribeTopics.preprocess_args,
-                return_value=self.topics_partitions,
-        ):
-            args = mock.Mock(topics=["foo", "bar", "baz"], topic=None, partitions=[0, 1, 2])
-
-            with pytest.raises(SystemExit):
-                UnsubscribeTopics.run(args, self.cluster_config)
-
     def test_run_unsubscribe_only_topics(self, client, zk, zk_unsubscriber, kafka_unsubscriber):
         with mock.patch.object(
                 UnsubscribeTopics,
@@ -141,18 +117,6 @@ class TestUnsubscribeTopics(object):
             args = mock.Mock(topics=["topic1", "topic3"], topic=None, partitions=None)
 
             UnsubscribeTopics.run(args, self.cluster_config)
-
-    def test_run_unsuscribe_missing_topics(self, client, zk, zk_unsubscriber, kafka_unsubscriber):
-        with mock.patch.object(
-                UnsubscribeTopics,
-                'preprocess_args',
-                spec=UnsubscribeTopics.preprocess_args,
-                return_value=self.topics_partitions,
-        ):
-            args = mock.Mock(topics=["topic2", "baz"], topic=None, partitions=None)
-
-            with pytest.raises(SystemExit):
-                UnsubscribeTopics.run(args, self.cluster_config)
 
     def test_unsubscribe_some_partitions_left(self, zk):
         zk_obj = zk.return_value


### PR DESCRIPTION
This fixes a bug where using unsubscribe_topics with the --topics flag
displayed all of the subscribed topics of the given consumer group as
subject to change when only the topics supplied with --topics should be
changed.

The bug was cosmetic only, so no actual functionality was changed.