### PR TITLE
Allow for yelp-only usage of internal pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
 install:
 - pip install tox tox-travis
 script:
-- tox
+- tox -i https://pypi.python.org/simple
 deploy:
   provider: pypi
   user: yelplabs

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+ifeq ($(findstring .yelpcorp.com,$(shell hostname -f)), .yelpcorp.com)
+    export PIP_INDEX_URL ?= https://pypi.yelpcorp.com/simple
+else
+    export PIP_INDEX_URL ?= https://pypi.python.org/simple
+endif
+
+
 PACKAGE_VERSION := $(shell python setup.py --version)
 
 all: test

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,9 @@
 [tox]
 envlist = py{27,34,35,36}-unittest, py{27,34,35,36}-kafka{8,9,10,11}-dockeritest
+# The Makefile and .travis.yml override the index server to the public one when
+# running outside of Yelp.
+indexserver =
+    default = https://pypi.yelpcorp.com/simple
 tox_pip_extensions_ext_pip_custom_platform = true
 tox_pip_extensions_ext_venv_update = true
 


### PR DESCRIPTION
This is based off of https://github.com/Yelp/paasta/commit/49c1cd0c9c8c641ad3332360ba3c09ad9d8cac4c

Basically, we won't have to do the export PIP_INDEX_URL=... internally anymore.

I tested this both internally and externally, and it seemed to work.