### PR TITLE
Change import path for error classes #199

### DIFF
--- a/kafka_utils/util/offsets.py
+++ b/kafka_utils/util/offsets.py
@@ -19,8 +19,8 @@ from collections import namedtuple
 
 import six
 from kafka.common import UnknownTopicOrPartitionError
-from kafka.structs import BrokerResponseError
-from kafka.structs import check_error
+from kafka.errors import BrokerResponseError
+from kafka.errors import check_error
 from kafka.structs import OffsetCommitRequestPayload
 from kafka.structs import OffsetFetchRequestPayload
 from kafka.structs import OffsetFetchResponsePayload


### PR DESCRIPTION
Even though there is a _from kafka.errors import *_ at the end of the kafka/structs.py file to support legacy imports, the change to import from the actual class fixes my bug of unresolved imports. Fixes #199