### PR TITLE
Bump version for `requests` module in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ pyOpenSSL==0.15.1
 pyasn1==0.1.7
 pytz==2018.4
 pycparser==2.10
-requests==2.7.0
+requests==2.21.0
 requests-futures==0.9.5
 retrying==1.3.3
 setproctitle==1.1.8


### PR DESCRIPTION
The current version uses deprecated features of `collections` module. This change fixes those deprecation warnings.

(All test cases pass on my machine.)