### PR TITLE
Fix bug if --max-movement-size=0

### DIFF
--- a/kafka_utils/kafka_cluster_manager/cmds/command.py
+++ b/kafka_utils/kafka_cluster_manager/cmds/command.py
@@ -262,7 +262,7 @@ class ClusterManagerCmd(object):
         curr_movements = 0
         curr_size = 0
         action_available = True
-        while curr_movements < max_movements and curr_size < max_movement_size and action_available:
+        while curr_movements < max_movements and curr_size <= max_movement_size and action_available:
             action_available = False
             for topic, actions in six.iteritems(topic_actions):
                 for action in actions:


### PR DESCRIPTION
There's a bug in decommission if max_movement_size becomes 0 and there are only 0-sized partitions left. This will mean no progress will be made.

This also makes the script more efficient in adding as many 0-size partitions as possible (up to given leader/partition movement cap) when doing other decommissions.