### PR TITLE
max movement size improvements

### DIFF
--- a/kafka_utils/kafka_cluster_manager/cluster_info/genetic_balancer.py
+++ b/kafka_utils/kafka_cluster_manager/cluster_info/genetic_balancer.py
@@ -607,13 +607,17 @@ class GeneticBalancer(ClusterBalancer):
             max_score += self.args.broker_leader_count_score_weight
 
         if self.args.max_movement_size is not None and score_movement:
+            # Avoid potential divide-by-zero error
+            max_movement = max(self.args.max_movement_size, 1)
             score += self.args.movement_size_score_weight * \
-                (1 - state.movement_size / self.args.max_movement_size)
+                (1 - state.movement_size / max_movement)
             max_score += self.args.movement_size_score_weight
 
         if self.args.max_leader_changes is not None and score_movement:
+            # Avoid potential divide-by-zero error
+            max_leader = max(self.args.max_leader_changes, 1)
             score += self.args.leader_change_score_weight * \
-                (1 - state.leader_movement_count / self.args.max_leader_changes)
+                (1 - state.leader_movement_count / max_leader)
             max_score += self.args.leader_change_score_weight
 
         return score / max_score

--- a/kafka_utils/kafka_cluster_manager/cmds/command.py
+++ b/kafka_utils/kafka_cluster_manager/cmds/command.py
@@ -164,6 +164,7 @@ class ClusterManagerCmd(object):
         max_partition_movements,
         max_leader_only_changes,
         max_movement_size=DEFAULT_MAX_MOVEMENT_SIZE,
+        force_progress=False,
     ):
         """Reduce the assignment based on the total actions.
 
@@ -179,6 +180,7 @@ class ClusterManagerCmd(object):
                                 final set of actions
         max_leader_only_changes:Maximum number of actions with leader only changes
         max_movement_size:      Maximum size, in bytes, to move in final set of actions
+        force_progress:         Whether to force progress if max_movement_size is too small
         :return:
         :reduced_assignment:    Final reduced assignment
         """
@@ -219,6 +221,25 @@ class ClusterManagerCmd(object):
             cluster_topology,
             max_movement_size,
         )
+
+        # Ensure progress is made if force_progress=True
+        if len(reduced_actions) == 0 and force_progress:
+            largest_size = max([cluster_topology.partitions[t_p[0]].size for t_p in partition_change_count])
+            self.log.warning(
+                '--max-movement-size={max_movement_size} is too small, using largest size'
+                ' in set of partitions to move, {largest_size} instead to force progress'.format(
+                    max_movement_size=max_movement_size,
+                    largest_size=largest_size,
+                )
+            )
+            max_movement_size = largest_size
+            reduced_actions = self._extract_actions_unique_topics(
+                partition_change_count,
+                max_partition_movements,
+                cluster_topology,
+                max_movement_size,
+            )
+
         reduced_partition_changes = [
             (t_p, new_assignment[t_p]) for t_p in reduced_actions
         ]

--- a/kafka_utils/kafka_cluster_manager/cmds/command.py
+++ b/kafka_utils/kafka_cluster_manager/cmds/command.py
@@ -224,15 +224,15 @@ class ClusterManagerCmd(object):
 
         # Ensure progress is made if force_progress=True
         if len(reduced_actions) == 0 and force_progress:
-            largest_size = max([cluster_topology.partitions[t_p[0]].size for t_p in partition_change_count])
+            smallest_size = min([cluster_topology.partitions[t_p[0]].size for t_p in partition_change_count])
             self.log.warning(
-                '--max-movement-size={max_movement_size} is too small, using largest size'
-                ' in set of partitions to move, {largest_size} instead to force progress'.format(
+                '--max-movement-size={max_movement_size} is too small, using smallest size'
+                ' in set of partitions to move, {smallest_size} instead to force progress'.format(
                     max_movement_size=max_movement_size,
-                    largest_size=largest_size,
+                    smallest_size=smallest_size,
                 )
             )
-            max_movement_size = largest_size
+            max_movement_size = smallest_size
             reduced_actions = self._extract_actions_unique_topics(
                 partition_change_count,
                 max_partition_movements,

--- a/kafka_utils/kafka_cluster_manager/cmds/decommission.py
+++ b/kafka_utils/kafka_cluster_manager/cmds/decommission.py
@@ -108,6 +108,11 @@ class DecommissionCmd(ClusterManagerCmd):
             for partition in partitions_to_move
         )
 
+        smallest_size = min(
+            partition.size
+            for partition in partitions_to_move
+        )
+
         if self.args.auto_max_movement_size:
             self.args.max_movement_size = largest_size
             self.log.info(
@@ -121,10 +126,10 @@ class DecommissionCmd(ClusterManagerCmd):
             if not self.args.force_progress:
                 self.log.error(
                     'Max partition movement size is only {max_movement_size},'
-                    ' but largest partition to move in set of brokers to decommission'
-                    ' is size {largest_size}.'
-                    ' The decommission will not make progress.'.format(
+                    ' but remaining partitions to move range from {smallest_size} to'
+                    ' {largest_size}. The decommission will not make progress'.format(
                         max_movement_size=self.args.max_movement_size,
+                        smallest_size=smallest_size,
                         largest_size=largest_size,
                     )
                 )
@@ -132,9 +137,10 @@ class DecommissionCmd(ClusterManagerCmd):
             else:
                 self.log.warning(
                     'Max partition movement size is only {max_movement_size},'
-                    ' but largest partition to move in set of brokers to decommission'
-                    ' is size {largest_size}. Progress may be slower than expected.'.format(
+                    ' but remaining partitions to move range from {smallest_size} to'
+                    ' {largest_size}. The decommission may be slower than expected'.format(
                         max_movement_size=self.args.max_movement_size,
+                        smallest_size=smallest_size,
                         largest_size=largest_size,
                     )
                 )

--- a/kafka_utils/kafka_cluster_manager/cmds/decommission.py
+++ b/kafka_utils/kafka_cluster_manager/cmds/decommission.py
@@ -19,7 +19,6 @@ import logging
 import sys
 
 from .command import ClusterManagerCmd
-from .command import DEFAULT_MAX_MOVEMENT_SIZE
 from kafka_utils.util import positive_float
 from kafka_utils.util import positive_int
 from kafka_utils.util.validation import assignment_to_plan
@@ -68,7 +67,7 @@ class DecommissionCmd(ClusterManagerCmd):
         subparser.add_argument(
             '--max-movement-size',
             type=positive_float,
-            default=DEFAULT_MAX_MOVEMENT_SIZE,
+            default=None,
             help='Maximum total size of the partitions moved in the final set'
                  ' of actions. Since each PartitionMeasurer implementation'
                  ' defines its own notion of size, the size unit to use will'
@@ -105,7 +104,7 @@ class DecommissionCmd(ClusterManagerCmd):
                 )
             )
 
-        if self.args.max_movement_size < largest_size:
+        if self.args.max_movement_size and self.args.max_movement_size < largest_size:
             self.log.error(
                 'Max partition movement size is only {max_movement_size},'
                 ' but largest partition to move in set of brokers to decommission'

--- a/kafka_utils/kafka_cluster_manager/cmds/decommission.py
+++ b/kafka_utils/kafka_cluster_manager/cmds/decommission.py
@@ -93,9 +93,9 @@ class DecommissionCmd(ClusterManagerCmd):
         return subparser
 
     def run_command(self, cluster_topology, cluster_balancer):
-        if self.args.force_progress and not self.args.max_movement_size:
+        if self.args.force_progress and self.args.max_movement_size is None:
             self.log.error(
-                '--force-progress must be used with --max-movement-size only',
+                '--force-progress must be used with --max-movement-size',
             )
             sys.exit(1)
         # Obtain the largest partition in the set of partitions we will move

--- a/tests/kafka_cluster_manager/cmds/command_test.py
+++ b/tests/kafka_cluster_manager/cmds/command_test.py
@@ -268,7 +268,7 @@ class TestClusterManagerCmd(object):
             force_progress=True,
         )
 
-        # Verify proposed plan -- largest size in the cluster is 1, so expect 1
+        # Verify proposed plan -- smallest size in the cluster is 1, so expect 1
         assert len(proposed_assignment) == 1
 
     def test_reduced_proposed_plan_empty_new_assignment(self, cmd, orig_assignment, empty_cluster_topology):

--- a/tests/kafka_cluster_manager/cmds/command_test.py
+++ b/tests/kafka_cluster_manager/cmds/command_test.py
@@ -253,6 +253,24 @@ class TestClusterManagerCmd(object):
         # Verify no proposed plan
         assert proposed_assignment == {}
 
+    def test_reduced_proposed_plan_force_progress(
+        self,
+        cmd,
+        orig_assignment,
+        cluster_topology,
+    ):
+        proposed_assignment = cmd.get_reduced_assignment(
+            orig_assignment,
+            cluster_topology,
+            max_partition_movements=2,
+            max_leader_only_changes=0,
+            max_movement_size=0,
+            force_progress=True,
+        )
+
+        # Verify proposed plan -- largest size in the cluster is 1, so expect 1
+        assert len(proposed_assignment) == 1
+
     def test_reduced_proposed_plan_empty_new_assignment(self, cmd, orig_assignment, empty_cluster_topology):
         # Provide empty assignment
         proposed_assignment = cmd.get_reduced_assignment(


### PR DESCRIPTION
Need to do some more manual testing still.

- I noticed decommission still uses the scoring in genetic balancer, which takes in `self.args.max_movement_size` (passed in from the cmd line). In the previous change to decommission where we added this argument, we set the default value to be `float('inf')`. The issue is that now this `float('inf')` will be used in genetic balancer for scoring even if the user did not pass in `--max-movement-size`. So we set the default value to be `None` in the parser (matching the rebalance command) and only set it to `float('inf')` when we reduce the overall assignment.
- I also noticed that passing in `--max-movement-size 0` will cause divide-by-zero error in genetic balancer, so I just coerced it to 1 to avoid the issue in the balancer. Same with `--max-leader-changes`
- Lastly, a new `--force-progress` flag which, when combined with `--max-movement-size`, will ensure that progress will be made during decommission in case `--max-movement-size` is less than one of the partitions left to move. Basically, if during the reducing assignment phase we have reduced the assignment to 0 actions, we recompute reduction using a larger `--max-movement-size` (set to the largest partition left to move). It should only kick in at the tail end of a decommission.