### PR TITLE
Implement --head option for kafka-check command

### DIFF
--- a/kafka_utils/kafka_check/main.py
+++ b/kafka_utils/kafka_check/main.py
@@ -153,10 +153,10 @@ def validate_args(args):
                     args.json,
                 )
 
-    if args.head and not args.verbose:
+    if args.head != -1 and not args.verbose:
         terminate(
             status_code.WARNING,
-            prepare_terminate_message("--head option works only as addition --verbose"),
+            prepare_terminate_message("--head option works only as addition to --verbose option"),
             args.json,
         )
 

--- a/kafka_utils/kafka_check/status_code.py
+++ b/kafka_utils/kafka_check/status_code.py
@@ -37,18 +37,18 @@ def prepare_terminate_message(string):
     }
 
 
-def terminate(signal, msg, json):
+def terminate(err_code, msg, json):
     if json:
         output = {
-            'status': STATUS_STRING[signal],
+            'status': STATUS_STRING[err_code],
             'data': msg['raw'],
         }
         print_json(output)
     else:
         print('{status}: {msg}'.format(
-            status=STATUS_STRING[signal],
+            status=STATUS_STRING[err_code],
             msg=msg['message'],
         ))
         if 'verbose' in msg:
             print(msg['verbose'])
-    sys.exit(signal)
+    sys.exit(err_code)

--- a/tests/kafka_check/test_min_isr.py
+++ b/tests/kafka_check/test_min_isr.py
@@ -187,7 +187,7 @@ def test_prepare_output_ok_no_verbose():
             'not_enough_replicas_count': 0,
         }
     }
-    assert _prepare_output([], False) == origin
+    assert _prepare_output([], False, -1) == origin
 
 
 def test_prepare_output_ok_verbose():
@@ -198,7 +198,7 @@ def test_prepare_output_ok_verbose():
             'partitions': [],
         }
     }
-    assert _prepare_output([], True) == origin
+    assert _prepare_output([], True, -1) == origin
 
 
 def test_prepare_output_critical_no_verbose():
@@ -211,7 +211,7 @@ def test_prepare_output_critical_no_verbose():
             'not_enough_replicas_count': 2,
         }
     }
-    assert _prepare_output(NOT_IN_SYNC_PARTITIONS, False) == origin
+    assert _prepare_output(NOT_IN_SYNC_PARTITIONS, False, -1) == origin
 
 
 def test_prepare_output_critical_verbose():
@@ -243,4 +243,29 @@ def test_prepare_output_critical_verbose():
             ],
         }
     }
-    assert _prepare_output(NOT_IN_SYNC_PARTITIONS, True) == origin
+    assert _prepare_output(NOT_IN_SYNC_PARTITIONS, True, -1) == origin
+
+
+def test_prepare_output_critical_verbose_with_head():
+    origin = {
+        'message': (
+            "2 partition(s) have the number of replicas in "
+            "sync that is lower than the specified min ISR."
+        ),
+        'verbose': (
+            "Top 1 partitions:\n"
+            "isr=1 is lower than min_isr=3 for topic_0:0"
+        ),
+        'raw': {
+            'not_enough_replicas_count': 2,
+            'partitions': [
+                {
+                    'isr': 1,
+                    'min_isr': 3,
+                    'partition': 0,
+                    'topic': 'topic_0'
+                }
+            ],
+        }
+    }
+    assert _prepare_output(NOT_IN_SYNC_PARTITIONS, True, 1) == origin

--- a/tests/kafka_check/test_offline.py
+++ b/tests/kafka_check/test_offline.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+
+from kafka_utils.kafka_check.commands.offline import _prepare_output
+
+
+OFFLINE_PARTITIONS = [
+    ('Topic0', 0),
+    ('Topic0', 1),
+    ('Topic13', 13),
+]
+
+
+def test_prepare_output_ok_no_verbose():
+    expected = {
+        'message': "No offline partitions.",
+        'raw': {
+            'offline_count': 0,
+        }
+    }
+    assert _prepare_output([], False, -1) == expected
+
+
+def test_prepare_output_ok_verbose():
+    expected = {
+        'message': "No offline partitions.",
+        'raw': {
+            'offline_count': 0,
+            'partitions': [],
+        }
+    }
+    assert _prepare_output([], True, -1) == expected
+
+
+def test_prepare_output_critical_verbose():
+    expected = {
+        'message': "3 offline partitions.",
+        'verbose': (
+            "Partitions:\n"
+            "Topic0:0\n"
+            "Topic0:1\n"
+            "Topic13:13"
+        ),
+        'raw': {
+            'offline_count': 3,
+            'partitions': [
+                {'partition': 0, 'topic': 'Topic0'},
+                {'partition': 1, 'topic': 'Topic0'},
+                {'partition': 13, 'topic': 'Topic13'},
+            ],
+        }
+    }
+    assert _prepare_output(OFFLINE_PARTITIONS, True, -1) == expected
+
+
+def test_prepare_output_critical_verbose_with_head():
+    expected = {
+        'message': "3 offline partitions.",
+        'verbose': (
+            "Top 2 partitions:\n"
+            "Topic0:0\n"
+            "Topic0:1"
+        ),
+        'raw': {
+            'offline_count': 3,
+            'partitions': [
+                {'partition': 0, 'topic': 'Topic0'},
+                {'partition': 1, 'topic': 'Topic0'},
+            ],
+        }
+    }
+    assert _prepare_output(OFFLINE_PARTITIONS, True, 2) == expected

--- a/tests/kafka_check/test_replica_unavailability.py
+++ b/tests/kafka_check/test_replica_unavailability.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+
+from kafka_utils.kafka_check.commands.replica_unavailability import _prepare_output
+
+
+UNAVAILABLE_REPLICAS = [
+    ('Topic0', 0),
+    ('Topic0', 1),
+    ('Topic13', 13),
+]
+
+UNAVAILABLE_BROKERS = [123456, 987456]
+
+
+def test_prepare_output_ok_no_verbose():
+    expected = {
+        'message': "All replicas available for communication.",
+        'raw': {
+            'replica_unavailability_count': 0,
+        }
+    }
+    assert _prepare_output([], [], False, -1) == expected
+
+
+def test_prepare_output_ok_verbose():
+    expected = {
+        'message': "All replicas available for communication.",
+        'raw': {
+            'replica_unavailability_count': 0,
+            'partitions': [],
+        }
+    }
+    assert _prepare_output([], [], True, -1) == expected
+
+
+def test_prepare_output_critical_verbose():
+    expected = {
+        'message': "3 replicas unavailable for communication. Unavailable Brokers: 123456, 987456",
+        'verbose': (
+            "Partitions:\n"
+            "Topic0:0\n"
+            "Topic0:1\n"
+            "Topic13:13"
+        ),
+        'raw': {
+            'replica_unavailability_count': 3,
+            'partitions': [
+                {'partition': 0, 'topic': 'Topic0'},
+                {'partition': 1, 'topic': 'Topic0'},
+                {'partition': 13, 'topic': 'Topic13'},
+            ],
+        }
+    }
+    assert _prepare_output(UNAVAILABLE_REPLICAS, UNAVAILABLE_BROKERS, True, -1) == expected
+
+
+def test_prepare_output_critical_verbose_with_head():
+    expected = {
+        'message': "3 replicas unavailable for communication. Unavailable Brokers: 123456, 987456",
+        'verbose': (
+            "Top 2 partitions:\n"
+            "Topic0:0\n"
+            "Topic0:1"
+        ),
+        'raw': {
+            'replica_unavailability_count': 3,
+            'partitions': [
+                {'partition': 0, 'topic': 'Topic0'},
+                {'partition': 1, 'topic': 'Topic0'},
+            ],
+        }
+    }
+    assert _prepare_output(UNAVAILABLE_REPLICAS, UNAVAILABLE_BROKERS, True, 2) == expected

--- a/tests/kafka_check/test_replication_factor.py
+++ b/tests/kafka_check/test_replication_factor.py
@@ -158,7 +158,7 @@ def test_prepare_output_ok_no_verbose():
             'topics_with_wrong_replication_factor_count': 0,
         }
     }
-    assert _prepare_output([], False) == expected
+    assert _prepare_output([], False, -1) == expected
 
 
 def test_prepare_output_ok_verbose():
@@ -169,7 +169,7 @@ def test_prepare_output_ok_verbose():
             'topics': [],
         }
     }
-    assert _prepare_output([], True) == expected
+    assert _prepare_output([], True, -1) == expected
 
 
 def test_prepare_output_critical_no_verbose():
@@ -179,7 +179,7 @@ def test_prepare_output_critical_no_verbose():
             'topics_with_wrong_replication_factor_count': 2,
         }
     }
-    assert _prepare_output(TOPICS_WITH_WRONG_RP, False) == expected
+    assert _prepare_output(TOPICS_WITH_WRONG_RP, False, -1) == expected
 
 
 def test_prepare_output_critical_verbose():
@@ -206,4 +206,25 @@ def test_prepare_output_critical_verbose():
             ],
         }
     }
-    assert _prepare_output(TOPICS_WITH_WRONG_RP, True) == expected
+    assert _prepare_output(TOPICS_WITH_WRONG_RP, True, -1) == expected
+
+
+def test_prepare_output_critical_verbose_with_head_limit():
+    expected = {
+        'message': '2 topic(s) have replication factor lower than specified min ISR + 1.',
+        'verbose': (
+            "Top 1 topics:\n"
+            "replication_factor=3 is lower than min_isr=3 + 1 for topic_0"
+        ),
+        'raw': {
+            'topics_with_wrong_replication_factor_count': 2,
+            'topics': [
+                {
+                    'min_isr': 3,
+                    'topic': 'topic_0',
+                    'replication_factor': 3,
+                },
+            ],
+        }
+    }
+    assert _prepare_output(TOPICS_WITH_WRONG_RP, True, 1) == expected


### PR DESCRIPTION
Add few more tests for formatting functions of subcommands of kafka-check

We need that param to be able to pass affected topics/partitions into sensu.
Bash `| head/tail` pipeline doesn't work properly because of unusual handling of SIGPIPE on python side. Also bash pipe hides exit code of the first command. Python solution seems more sustainable.