### PR TITLE
Fix bug with --max-movement-size == None

### DIFF
--- a/kafka_utils/kafka_cluster_manager/cmds/command.py
+++ b/kafka_utils/kafka_cluster_manager/cmds/command.py
@@ -27,7 +27,6 @@ from kafka_utils.kafka_cluster_manager. \
 from kafka_utils.util.validation import assignment_to_plan
 from kafka_utils.util.zookeeper import ZK
 
-
 DEFAULT_MAX_MOVEMENT_SIZE = float('inf')
 
 

--- a/kafka_utils/kafka_cluster_manager/cmds/decommission.py
+++ b/kafka_utils/kafka_cluster_manager/cmds/decommission.py
@@ -19,6 +19,7 @@ import logging
 import sys
 
 from .command import ClusterManagerCmd
+from .command import DEFAULT_MAX_MOVEMENT_SIZE
 from kafka_utils.util import positive_float
 from kafka_utils.util import positive_int
 from kafka_utils.util.validation import assignment_to_plan
@@ -69,7 +70,7 @@ class DecommissionCmd(ClusterManagerCmd):
         movement_size_group.add_argument(
             '--max-movement-size',
             type=positive_float,
-            default=None,
+            default=DEFAULT_MAX_MOVEMENT_SIZE,
             help='Maximum total size of the partitions moved in the final set'
                  ' of actions. Since each PartitionMeasurer implementation'
                  ' defines its own notion of size, the size unit to use will'
@@ -93,7 +94,8 @@ class DecommissionCmd(ClusterManagerCmd):
         return subparser
 
     def run_command(self, cluster_topology, cluster_balancer):
-        if self.args.force_progress and self.args.max_movement_size is None:
+        # If the max_movement_size is still default, then the user did not input a value for it
+        if self.args.force_progress and self.args.max_movement_size == DEFAULT_MAX_MOVEMENT_SIZE:
             self.log.error(
                 '--force-progress must be used with --max-movement-size',
             )


### PR DESCRIPTION
We incorrectly passed down Nonetype value as argument instead of default argument, `float('inf')`.

This is because I incorrectly assumed passing in kwarg as `None` would result in default kwarg value downstream overwriting it.