### PR TITLE
Human friendly output for bytes in decommission

### DIFF
--- a/kafka_utils/kafka_cluster_manager/cmds/command.py
+++ b/kafka_utils/kafka_cluster_manager/cmds/command.py
@@ -19,6 +19,7 @@ import logging
 import sys
 from collections import defaultdict
 
+import humanfriendly
 import six
 from six.moves import input
 
@@ -227,8 +228,8 @@ class ClusterManagerCmd(object):
             self.log.warning(
                 '--max-movement-size={max_movement_size} is too small, using smallest size'
                 ' in set of partitions to move, {smallest_size} instead to force progress'.format(
-                    max_movement_size=max_movement_size,
-                    smallest_size=smallest_size,
+                    max_movement_size=humanfriendly.format_size(max_movement_size),
+                    smallest_size=humanfriendly.format_size(smallest_size),
                 )
             )
             max_movement_size = smallest_size

--- a/kafka_utils/kafka_cluster_manager/cmds/decommission.py
+++ b/kafka_utils/kafka_cluster_manager/cmds/decommission.py
@@ -18,6 +18,8 @@ from __future__ import print_function
 import logging
 import sys
 
+import humanfriendly
+
 from .command import ClusterManagerCmd
 from .command import DEFAULT_MAX_MOVEMENT_SIZE
 from kafka_utils.util import positive_float
@@ -118,8 +120,9 @@ class DecommissionCmd(ClusterManagerCmd):
         if self.args.auto_max_movement_size:
             self.args.max_movement_size = largest_size
             self.log.info(
-                'Auto-max-movement-size: using {max_movement_size} as'
+                'Auto-max-movement-size: using {human_max_movement_size} ({max_movement_size}) as'
                 ' max-movement-size.'.format(
+                    human_max_movement_size=humanfriendly.format_size(self.args.max_movement_size),
                     max_movement_size=self.args.max_movement_size,
                 )
             )
@@ -130,9 +133,9 @@ class DecommissionCmd(ClusterManagerCmd):
                     'Max partition movement size is only {max_movement_size},'
                     ' but remaining partitions to move range from {smallest_size} to'
                     ' {largest_size}. The decommission will not make progress'.format(
-                        max_movement_size=self.args.max_movement_size,
-                        smallest_size=smallest_size,
-                        largest_size=largest_size,
+                        max_movement_size=humanfriendly.format_size(self.args.max_movement_size),
+                        smallest_size=humanfriendly.format_size(smallest_size),
+                        largest_size=humanfriendly.format_size(largest_size),
                     )
                 )
                 sys.exit(1)
@@ -141,9 +144,9 @@ class DecommissionCmd(ClusterManagerCmd):
                     'Max partition movement size is only {max_movement_size},'
                     ' but remaining partitions to move range from {smallest_size} to'
                     ' {largest_size}. The decommission may be slower than expected'.format(
-                        max_movement_size=self.args.max_movement_size,
-                        smallest_size=smallest_size,
-                        largest_size=largest_size,
+                        max_movement_size=humanfriendly.format_size(self.args.max_movement_size),
+                        smallest_size=humanfriendly.format_size(smallest_size),
+                        largest_size=humanfriendly.format_size(largest_size),
                     )
                 )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ cffi==1.12.2
 ecdsa==0.13
 enum34==1.1.6
 futures==3.2.0
+humanfriendly==4.8
 jsonschema==3.0.1
 kafka-python==1.4.4
 kazoo==2.6.1

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         "scripts/kafka-corruption-check",
     ],
     install_requires=[
+        "humanfriendly>=4.8",
         "kafka-python>=1.3.2,<1.5.0",
         "kazoo>=2.0,<3.0.0",
         "PyYAML>3.10",


### PR DESCRIPTION
Adds a new dependency humanfriendly that we can start using to display bytes and other numbers in human friendly values

Some sample output

```
WARNING:DecommissionCmd:Max partition movement size is only 13.0 bytes, but remaining partitions to move range from 0.0 bytes to 4.12 GB. The decommission may be slower than expected
INFO:DecommissionCmd:Auto-max-movement-size: using 4.12 GB (4120645437.0) as max-movement-size.
ERROR:DecommissionCmd:Max partition movement size is only 1.0 byte, but remaining partitions to move range from 0.0 bytes to 4.12 GB. The decommission will not make progress
```

Wasn't able to test the case in `command.py` but it should work the same.

