### PR TITLE
Add kafka-manual-throttle command

### DIFF
--- a/kafka_utils/kafka_manual_throttle/__init__.py
+++ b/kafka_utils/kafka_manual_throttle/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/kafka_utils/kafka_manual_throttle/main.py
+++ b/kafka_utils/kafka_manual_throttle/main.py
@@ -1,0 +1,191 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import argparse
+import logging
+import sys
+
+from kafka_utils.util import config
+from kafka_utils.util.zookeeper import ZK
+
+
+LEADER_THROTTLE_RATE_CONFIGURATION = "leader.replication.throttled.rate"
+FOLLOWER_THROTTLE_RATE_CONFIGURATION = "follower.replication.throttled.rate"
+
+
+def parse_opts():
+    parser = argparse.ArgumentParser(
+        description='Manually applies throttle values for brokers in a Kafka cluster',
+    )
+    parser.add_argument(
+        '--cluster-type',
+        '-t',
+        required=True,
+        help='cluster type, e.g. "standard"',
+    )
+    parser.add_argument(
+        '--cluster-name',
+        '-c',
+        help='cluster name, e.g. "uswest1-devc" (defaults to local cluster)',
+    )
+    parser.add_argument(
+        '--discovery-base-path',
+        dest='discovery_base_path',
+        type=str,
+        help='Path of the directory containing the <cluster_type>.yaml config',
+    )
+    parser.add_argument(
+        '--leader-throttle',
+        type=int,
+        required=False,
+        help='value (B/s) of the leader throttle to apply for brokers',
+    )
+    parser.add_argument(
+        '--follower-throttle',
+        type=int,
+        required=False,
+        help='value (B/s) of the leader throttle to apply for brokers',
+    )
+    parser.add_argument(
+        '--clear',
+        help='if set, throttles will be cleared instead of being set',
+        action='store_true',
+    )
+    parser.add_argument(
+        '-v',
+        '--verbose',
+        help='print verbose execution information. Default: %(default)s',
+        action="store_true",
+    )
+    return parser.parse_args()
+
+
+def validate_opts(opts, brokers_num):
+    """
+    Basic option validation.
+
+    True if the options are valid, False otherwise.
+
+    :opts : the command line options
+    :returns : bool
+    """
+    if opts.clear:
+        if opts.leader_throttle is not None:
+            print("Error: --clear cannot be used with --leader-throttle")
+            return False
+        if opts.follower_throttle is not None:
+            print("Error: --clear cannot be used with --follower-throttle")
+            return False
+    else:
+        if opts.leader_throttle < 0:
+            print("Error: --leader-throttle must be >= 0")
+            return False
+        if opts.follower_throttle < 0:
+            print("Error: --follower-throttle must be >= 0")
+            return False
+    return True
+
+
+def apply_throttles(zk, brokers, leader_throttle, follower_throttle):
+    """
+    Apply new leader/follower replication throttles to the given brokers
+
+    :zk : a ZK client
+    :brokers : a collection of broker ids
+    :leader_throttle : new leader replication throttle (in B/s)
+    :follower_throttle : new follower replication throttle (in B/s)
+    """
+    for broker_id in brokers:
+        write_throttle(zk, broker_id, str(leader_throttle), str(follower_throttle))
+
+
+def clear_throttles(zk, brokers):
+    """
+    Clear replication throttles for the given brokers.
+
+    :zk : a ZK client
+    :brokers : a collection of broker ids
+    """
+    for broker_id in brokers:
+        write_throttle(zk, broker_id, None, None)
+
+
+def write_throttle(zk, broker_id, leader_throttle, follower_throttle):
+    """
+    Write leader/follower replication throttle rates for a given broker.
+
+    If a given replication throttle is None, the configuration will be cleared
+    from the broker instead of applying a new one.
+
+    More details can be found in:
+        https://kafka.apache.org/documentation/#rep-throttle
+
+    :zk : a ZK client
+    :broker_id : broker to change replication throttles for
+    :leader_throttle : new leader replication throttle (in B/s) or None
+    :follower_throttle : new follower replication throttle (in B/s) or None
+    """
+    config = zk.get_broker_config(broker_id)
+
+    if leader_throttle is not None:
+        config[LEADER_THROTTLE_RATE_CONFIGURATION] = leader_throttle
+    else:
+        config.pop(LEADER_THROTTLE_RATE_CONFIGURATION, None)
+
+    if follower_throttle is not None:
+        config[FOLLOWER_THROTTLE_RATE_CONFIGURATION] = follower_throttle
+    else:
+        config.pop(FOLLOWER_THROTTLE_RATE_CONFIGURATION, None)
+
+    zk.set_broker_config(broker_id, config)
+
+
+def run():
+    opts = parse_opts()
+    if opts.verbose:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.WARN)
+
+    if not validate_opts(opts):
+        sys.exit(1)
+
+    cluster_config = config.get_cluster_config(
+        opts.cluster_type,
+        opts.cluster_name,
+        opts.discovery_base_path,
+    )
+
+    print("Applying throttles")
+
+    with ZK(cluster_config) as zk:
+        brokers = zk.get_brokers(names_only=True)
+
+        if not opts.clear:
+            apply_throttles(
+                zk,
+                brokers,
+                opts.leader_throttle,
+                opts.follower_throttle,
+                opts.verbose,
+            )
+        else:
+            clear_throttles(zk, brokers, opts.verbose)
+
+    print("Throttles applied.")
+    print("NOTE: Do not forget to --clear throttles once the reassignment plan completes.")

--- a/kafka_utils/util/zookeeper.py
+++ b/kafka_utils/util/zookeeper.py
@@ -117,28 +117,11 @@ class ZK:
 
         :rtype : dict of configuration
         """
-        try:
-            config_data = load_json(
-                self.get(
-                    "/config/topics/{topic}".format(topic=topic)
-                )[0]
-            )
-        except NoNodeError as e:
-
-            # Kafka version before 0.8.1 does not have "/config/topics/<topic_name>" path in ZK and
-            # if the topic exists, return default dict instead of raising an Exception.
-            # Ref: https://cwiki.apache.org/confluence/display/KAFKA/Kafka+data+structures+in+Zookeeper.
-
-            topics = self.get_topics(topic_name=topic, fetch_partition_state=False)
-            if len(topics) > 0:
-                _log.info("Configuration not available for topic {topic}.".format(topic=topic))
-                config_data = {"config": {}}
-            else:
-                _log.error(
-                    "topic {topic} not found.".format(topic=topic)
-                )
-                raise e
-        return config_data
+        return self._get_entity_config(
+            "topics",
+            topic,
+            lambda topic: len(self.get_topics(topic_name=topic, fetch_partition_state=False)) > 0,
+        )
 
     def set_topic_config(self, topic, value, kafka_version=(0, 10, )):
         """Set configuration information for specified topic.
@@ -151,34 +134,106 @@ class ZK:
             Defaults to (0, 10, x). Kafka version 9 and kafka 10
             support this feature.
         """
+        self._set_entity_config("topics", topic, value, kafka_version)
+
+    def get_broker_config(self, broker_id):
+        """Get configuration information for specified broker.
+
+        :rtype : dict of configuration
+        """
+        return self._get_entity_config(
+            "brokers",
+            broker_id,
+            lambda broker_id: broker_id in self.get_brokers(names_only=True)
+        )
+
+    def set_broker_config(self, broker_id, value, kafka_version=(0, 10, )):
+        """Set configuration information for specified broker.
+
+        :broker_id : broker whose configuration needs to be changed
+        :value :  config value with which the topic needs to be
+            updated with. This would be of the form key=value.
+            Example 'cleanup.policy=compact'
+        :kafka_version :tuple kafka version the brokers are running on.
+            Defaults to (0, 10, x). Kafka version 9 and kafka 10
+            support this feature.
+        """
+        return self._set_entity_config("brokers", broker_id, value, kafka_version)
+
+    def _get_entity_config(self, entity_type, entity_name, entity_exists):
+        """Get configuration information for specified broker.
+
+        :entity_type : "brokers" or "topics"
+        :entity_name : broker id or topic name
+        :entity_exists : fn(entity_name) -> bool to determine whether an entity
+                            exists. used to determine whether to throw an exception
+                            when a configuration cannot be found for the given entity_name
+        :rtype : dict of configuration
+        """
+        assert entity_type in ("brokers", "topics"), "Supported entities are brokers and topics"
+
+        try:
+            config_data = load_json(
+                self.get(
+                    "/config/{entity_type}/{entity_name}".format(entity_type=entity_type, entity_name=entity_name)
+                )[0]
+            )
+        except NoNodeError as e:
+            if entity_exists(entity_name):
+                _log.info("Configuration not available for {entity_type} {entity_name}.".format(
+                    entity_type=entity_type,
+                    entity_name=entity_name,
+                ))
+                config_data = {"config": {}}
+            else:
+                _log.error("{entity_type} {entity_name} not found".format(entity_type=entity_type, entity_name=entity_name))
+                raise e
+
+        return config_data
+
+    def _set_entity_config(self, entity_type, entity_name, value, kafka_version=(0, 10, )):
+        """Set configuration information for specified entity.
+
+        :entity_type : "brokers" or "topics"
+        :entity_name : broker id or topic name
+        :value :  config value with which the entity needs to be
+            updated with. This would be of the form key=value.
+            Example 'cleanup.policy=compact'
+        :kafka_version :tuple kafka version the brokers are running on.
+            Defaults to (0, 10, x). Kafka version 9 and kafka 10
+            support this feature.
+        """
+        assert entity_type in ("brokers", "topics"), "Supported entities are brokers and topics"
+
         config_data = dump_json(value)
 
         try:
             # Change value
             return_value = self.set(
-                "/config/topics/{topic}".format(topic=topic),
-                config_data
+                "/config/{entity_type}/{entity_name}".format(entity_type=entity_type, entity_name=entity_name),
+                config_data,
             )
+
             # Create change
-            version = kafka_version[1]
+            assert kafka_version >= (0, 9, ), "Feature supported with kafka 0.9 and above"
 
-            # this feature is supported in kafka 9 and kafka 10
-            assert version in (9, 10), "Feature supported with kafka 9 and kafka 10"
-
-            if version == 9:
+            if kafka_version < (0, 10, ):
                 # https://github.com/apache/kafka/blob/0.9.0.1/
                 #     core/src/main/scala/kafka/admin/AdminUtils.scala#L334
                 change_node = dump_json({
                     "version": 1,
-                    "entity_type": "topics",
-                    "entity_name": topic
+                    "entity_type": entity_type,
+                    "entity_name": entity_name,
                 })
-            else:  # kafka 10
+            else:  # kafka 0.10+
                 # https://github.com/apache/kafka/blob/0.10.2.1/
                 #     core/src/main/scala/kafka/admin/AdminUtils.scala#L574
                 change_node = dump_json({
                     "version": 2,
-                    "entity_path": "topics/" + topic,
+                    "entity_path": "{entity_type}/{entity_name}".format(
+                        entity_type=entity_type,
+                        entity_name=entity_name
+                    )
                 })
 
             self.create(
@@ -188,7 +243,7 @@ class ZK:
             )
         except NoNodeError as e:
             _log.error(
-                "topic {topic} not found.".format(topic=topic)
+                "{entity_type}: {entity_name} not found.".format(entity_type=entity_type, entity_name=entity_name)
             )
             raise e
         return return_value

--- a/kafka_utils/util/zookeeper.py
+++ b/kafka_utils/util/zookeeper.py
@@ -155,8 +155,7 @@ class ZK:
             updated with. This would be of the form key=value.
             Example 'cleanup.policy=compact'
         :kafka_version :tuple kafka version the brokers are running on.
-            Defaults to (0, 10, x). Kafka version 9 and kafka 10
-            support this feature.
+            Defaults to (0, 10, x). Versions above Kafka 0.9 support this feature.
         """
         return self._set_entity_config("brokers", broker_id, value, kafka_version)
 
@@ -200,8 +199,7 @@ class ZK:
             updated with. This would be of the form key=value.
             Example 'cleanup.policy=compact'
         :kafka_version :tuple kafka version the brokers are running on.
-            Defaults to (0, 10, x). Kafka version 9 and kafka 10
-            support this feature.
+            Defaults to (0, 10, x). Versions above Kafka 0.9 support this feature.
         """
         assert entity_type in ("brokers", "topics"), "Supported entities are brokers and topics"
 

--- a/scripts/kafka-manual-throttle
+++ b/scripts/kafka-manual-throttle
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+from kafka_utils.kafka_manual_throttle.main import run
+
+if __name__ == '__main__':
+    run()

--- a/tests/kafka_manual_throttle/test_main.py
+++ b/tests/kafka_manual_throttle/test_main.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+
+import mock
+import pytest
+
+from kafka_utils.kafka_manual_throttle import main
+from kafka_utils.util.zookeeper import ZK
+
+
+BROKER_ID = 0
+
+
+@pytest.fixture
+def mock_zk():
+    return mock.Mock(spec=ZK)
+
+
+def test_apply_throttles(mock_zk):
+    mock_zk.get_broker_config.return_value = {}
+
+    brokers = [0, 1, 2]
+    main.apply_throttles(mock_zk, brokers, 42, 24)
+
+    assert mock_zk.set_broker_config.call_count == len(brokers)
+
+    expected_config = {"leader.replication.throttled.rate": "42", "follower.replication.throttled.rate": "24"}
+    expected_set_calls = [
+        mock.call(0, expected_config),
+        mock.call(1, expected_config),
+        mock.call(2, expected_config),
+    ]
+
+    assert mock_zk.set_broker_config.call_args_list == expected_set_calls
+
+
+def test_clear_throttles(mock_zk):
+    mock_zk.get_broker_config.return_value = {"leader.replication.throttled.rate": "42", "follower.replication.throttled.rate": "24"}
+
+    brokers = [0, 1, 2]
+    main.clear_throttles(mock_zk, brokers)
+
+    assert mock_zk.set_broker_config.call_count == len(brokers)
+
+    expected_config = {}
+    expected_set_calls = [
+        mock.call(0, expected_config),
+        mock.call(1, expected_config),
+        mock.call(2, expected_config),
+    ]
+
+    assert mock_zk.set_broker_config.call_args_list == expected_set_calls
+
+
+@pytest.mark.parametrize(
+    "current_config,leader,follower,expected_config", [
+        ({}, None, None, {}),
+        ({}, 42, None, {"leader.replication.throttled.rate": 42}),
+        ({}, 42, 24, {"leader.replication.throttled.rate": 42, "follower.replication.throttled.rate": 24}),
+        (
+            {"leader.replication.throttled.rate": 42, "follower.replication.throttled.rate": 24},
+            None,
+            100,
+            {"follower.replication.throttled.rate": 100},
+        ),
+        (
+            {"other.config": "other"},
+            42,
+            24,
+            {"other.config": "other", "leader.replication.throttled.rate": 42, "follower.replication.throttled.rate": 24}
+        ),
+    ]
+)
+def test_write_throttle(mock_zk, current_config, leader, follower, expected_config):
+    mock_zk.get_broker_config.return_value = current_config
+
+    main.write_throttle(mock_zk, BROKER_ID, leader, follower)
+
+    assert mock_zk.set_broker_config.call_count == 1
+
+    expected_set_call = mock.call(BROKER_ID, expected_config)
+    assert mock_zk.set_broker_config.call_args_list == [expected_set_call]


### PR DESCRIPTION
NOTE: It may be easier for reviewers to have a look at each commit separately 🙂

-----

Add ZK.set_broker_config and ZK.get_broker_config

Getting/Setting broker configuration is neened to set replication throttles per broker.

Broker configurations can be changed the same way as topic
configurations, this commit refactors {set,get}_topic_config into
{set,get}_entity_config and use these to interact with broker and topic
configurations.

-----

Add kafka-manual-throttle command

This command allows to manually set or clear replication throttle values
for brokers in a cluster.

```
kafka-manual-throttle -t <type> -c <name> --leader 134217728 --follower 268435456
kafka-manual-throttle -t <type> -c <name> --clear
```