### PR TITLE
Fix configuration writing in kafka-manual-throttle

### DIFF
--- a/kafka_utils/kafka_manual_throttle/main.py
+++ b/kafka_utils/kafka_manual_throttle/main.py
@@ -157,7 +157,7 @@ def read_throttles(zk, brokers):
     throttles = {}
 
     for broker_id in brokers:
-        config = zk.get_broker_config(broker_id)
+        config = zk.get_broker_config(broker_id).get('config', {})
 
         leader_throttle = config.get(LEADER_THROTTLE_RATE_CONFIGURATION)
         follower_throttle = config.get(FOLLOWER_THROTTLE_RATE_CONFIGURATION)
@@ -206,7 +206,7 @@ def write_throttle(zk, broker_id, leader_throttle, follower_throttle):
     :leader_throttle : new leader replication throttle (in B/s) or None
     :follower_throttle : new follower replication throttle (in B/s) or None
     """
-    config = zk.get_broker_config(broker_id)
+    config = zk.get_broker_config(broker_id).get('config', {})
 
     if leader_throttle is not None:
         config[LEADER_THROTTLE_RATE_CONFIGURATION] = leader_throttle
@@ -218,7 +218,7 @@ def write_throttle(zk, broker_id, leader_throttle, follower_throttle):
     else:
         config.pop(FOLLOWER_THROTTLE_RATE_CONFIGURATION, None)
 
-    zk.set_broker_config(broker_id, config)
+    zk.set_broker_config(broker_id, {'config': config})
 
 
 def run():

--- a/tests/kafka_manual_throttle/test_main.py
+++ b/tests/kafka_manual_throttle/test_main.py
@@ -37,7 +37,10 @@ def test_apply_throttles(mock_zk):
 
     assert mock_zk.set_broker_config.call_count == len(brokers)
 
-    expected_config = {"leader.replication.throttled.rate": "42", "follower.replication.throttled.rate": "24"}
+    expected_config = {
+        "config": {"leader.replication.throttled.rate": "42", "follower.replication.throttled.rate": "24"},
+    }
+
     expected_set_calls = [
         mock.call(0, expected_config),
         mock.call(1, expected_config),
@@ -48,14 +51,14 @@ def test_apply_throttles(mock_zk):
 
 
 def test_clear_throttles(mock_zk):
-    mock_zk.get_broker_config.return_value = {"leader.replication.throttled.rate": "42", "follower.replication.throttled.rate": "24"}
+    mock_zk.get_broker_config.return_value = {"config": {"leader.replication.throttled.rate": "42", "follower.replication.throttled.rate": "24"}}
 
     brokers = [0, 1, 2]
     main.clear_throttles(mock_zk, brokers)
 
     assert mock_zk.set_broker_config.call_count == len(brokers)
 
-    expected_config = {}
+    expected_config = {"config": {}}
     expected_set_calls = [
         mock.call(0, expected_config),
         mock.call(1, expected_config),
@@ -85,11 +88,11 @@ def test_clear_throttles(mock_zk):
     ]
 )
 def test_write_throttle(mock_zk, current_config, leader, follower, expected_config):
-    mock_zk.get_broker_config.return_value = current_config
+    mock_zk.get_broker_config.return_value = {"config": current_config}
 
     main.write_throttle(mock_zk, BROKER_ID, leader, follower)
 
     assert mock_zk.set_broker_config.call_count == 1
 
-    expected_set_call = mock.call(BROKER_ID, expected_config)
+    expected_set_call = mock.call(BROKER_ID, {"config": expected_config})
     assert mock_zk.set_broker_config.call_args_list == [expected_set_call]


### PR DESCRIPTION
Instead of writing configuration in the `config` dict in Zookeeper,
kafka-manual-throttle was writing updates at the config toplevel. This
meant that Kafka was ignoring them.

Before:
{'config': {}, 'leader.replication.throttled.rate': XXXX}

After:
{'config': {'leader.replication.throttled.rate': XXXX}}