### PR TITLE
Fix itest on py27

### DIFF
--- a/docker/itest/Dockerfile
+++ b/docker/itest/Dockerfile
@@ -47,7 +47,7 @@ RUN apt-get update \
     python-pkg-resources \
     python-setuptools
 
-RUN pip install tox tox-travis
+RUN pip install tox tox-travis more-itertools==4.2.0
 
 COPY run_tests.sh /scripts/run_tests.sh
 RUN chmod 755 /scripts/run_tests.sh


### PR DESCRIPTION
The itest failure is due to a chain of dependencies that end up trying to
install more_itertools without specifying a version. `more_itertools`
dropped support for py27 with version 6.0.0, which causes failures when
trying to import it in a py27 environment with the same error as here:
https://github.com/pytest-dev/pytest/issues/4770

Why did it start failing this week? It looks like our internal pypi:
https://pypi.yelpcorp.com/simple/more-itertools/ has only had up to
version 4.2.0 recently, and @drmorr uploaded a wheel for v7.2.0
yesterday, which the py27 acceptance test is trying to install. It looks
like the old version of pip we’re using, as described in that github issue,
is trying to install the latest version of more-itertools, despite itest
being marked as only for py3, and failing in the itest.