### PR TITLE
KAFKA-23818_relax_pytz_version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         "kafka-python>=1.3.2,<1.5.0",
         "kazoo>=2.0,<3.0.0",
         "PyYAML>3.10",
-        "pytz>=2016.4",
+        "pytz>=2014.1",
         "requests-futures>0.9.0",
         "paramiko<2.5.0",
         "requests<3.0.0",


### PR DESCRIPTION
This pinned version is too strict and it is causing dependency conflicts in some places.
Relaxing the requirement in setup.py looks like it should be safe.