### PR TITLE
Fix travis build by unpinning docker version to be installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,6 @@ sudo: required
 services:
 - docker
 before_install:
-- sudo sh -c 'echo "deb https://apt.dockerproject.org/repo ubuntu-precise main" >
-  /etc/apt/sources.list.d/docker.list'
-- sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
-- sudo apt-get update
-- sudo apt-key update
-- sudo apt-get -qqy -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
-  install docker-engine
 - sudo rm /usr/local/bin/docker-compose
 - curl -L https://github.com/docker/compose/releases/download/1.7.0/docker-compose-`uname
   -s`-`uname -m` > docker-compose


### PR DESCRIPTION
Looks like we were trying to install an older version of docker over a new one.

My guess is the new one had some confs for systemd and the old one had some confs for upstart, and things didn't get cleaned up properly.

Let's just use the newer one.

