### PR TITLE
Add support for removing brokers in replace

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@
     -   id: autopep8-wrapper
         args: [--ignore=E501, --in-place]
     -   id: flake8
-        args: [--ignore=E501]
+        args: ["--ignore=W504,E501"]
 
 -   repo: https://github.com/asottile/reorder_python_imports.git
     sha: f3dfe379d2ea341c6cf54d926d4585b35dea9251

--- a/docker/itest/Dockerfile
+++ b/docker/itest/Dockerfile
@@ -45,6 +45,7 @@ RUN apt-get update \
     python-pkg-resources \
     python-setuptools
 
+RUN pip install -U pip
 RUN pip install tox tox-travis more-itertools==4.2.0
 
 COPY run_tests.sh /scripts/run_tests.sh

--- a/kafka_utils/kafka_cluster_manager/cluster_info/cluster_topology.py
+++ b/kafka_utils/kafka_cluster_manager/cluster_info/cluster_topology.py
@@ -155,20 +155,24 @@ class ClusterTopology(object):
         """Move all partitions in source broker to destination broker.
 
         :param source_id: source broker-id
-        :param dest_id: destination broker-id
+        :param dest_id: destination broker-id, or None (to remove source broker)
         :raises: InvalidBrokerIdError, when either of given broker-ids is invalid.
         """
         try:
             source = self.brokers[source_id]
-            dest = self.brokers[dest_id]
+            dest = None
+            if dest_id is not None:
+                dest = self.brokers[dest_id]
             # Move all partitions from source to destination broker
             for partition in source.partitions.copy():  # Partitions set changes
                 # We cannot move partition directly since that re-orders the
                 # replicas for the partition
                 source.partitions.remove(partition)
-                dest.partitions.add(partition)
+                if dest:
+                    dest.partitions.add(partition)
                 # Replace broker in replica
                 partition.replace(source, dest)
+
         except KeyError as e:
             self.log.error("Invalid broker id %s.", e.args[0])
             raise InvalidBrokerIdError(

--- a/kafka_utils/kafka_cluster_manager/cluster_info/partition.py
+++ b/kafka_utils/kafka_cluster_manager/cluster_info/partition.py
@@ -118,6 +118,10 @@ class Partition(object):
 
     def replace(self, source, dest):
         """Replace source broker with destination broker in replica set if found."""
+        if dest is None:
+            # Remove source if it's there
+            self.replicas.remove(source)
+            return
         for i, broker in enumerate(self.replicas):
             if broker == source:
                 self.replicas[i] = dest

--- a/tests/kafka_cluster_manager/cmds/replace_broker_test.py
+++ b/tests/kafka_cluster_manager/cmds/replace_broker_test.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+
+from argparse import Namespace
+
+import mock
+import pytest
+
+from kafka_utils.kafka_cluster_manager.cluster_info.partition_count_balancer \
+    import PartitionCountBalancer
+from kafka_utils.kafka_cluster_manager.cmds.replace \
+    import ReplaceBrokerCmd
+
+
+@pytest.fixture()
+def assignment():
+    return {
+        (u'T0', 0): [0, 1],
+        (u'T0', 1): [1, 2],
+    }
+
+
+@pytest.fixture()
+def brokers():
+    return {
+        0: {'host': 'host2'},
+        1: {'host': 'host2'},
+        2: {'host': 'host3'},
+        3: {'host': 'host4'},
+        4: {'host': 'host5'},
+    }
+
+
+class TestReplaceBrokerCmd(object):
+
+    def mock_args(self):
+        args = mock.Mock(spec=Namespace)
+        args.max_leader_changes = 10
+        args.max_partition_movements = 10
+        args.rf_change = False
+        args.rf_mismatch = False
+        args.topic_partition_filter = None
+        args.source_broker = 0
+        args.dest_broker = 3
+        return args
+
+    def test_filter_list(self, create_cluster_topology, assignment, brokers):
+        with mock.patch.object(ReplaceBrokerCmd, 'process_assignment'), mock.patch.object(ReplaceBrokerCmd, 'get_topic_filter') as mock_filter:
+            cmd = ReplaceBrokerCmd()
+            cmd.args = self.mock_args()
+            cmd.args.topic_partition_filter = 'foo'
+            mock_filter.return_value = {('T0', 0)}
+            ct = create_cluster_topology(assignment, brokers)
+            cb = PartitionCountBalancer(ct, cmd.args)
+            cmd.run_command(ct, cb)
+
+            assert cmd.process_assignment.call_count == 1
+            args, _ = cmd.process_assignment.call_args_list[0]
+            assignment = args[0]
+            assert len(assignment) == 1
+            assert set(assignment[('T0', 0)]) == set([3, 1])
+
+    def test_remove(self, create_cluster_topology, assignment, brokers):
+        with mock.patch.object(ReplaceBrokerCmd, 'process_assignment'), mock.patch.object(ReplaceBrokerCmd, 'get_topic_filter') as mock_filter:
+            cmd = ReplaceBrokerCmd()
+            cmd.args = self.mock_args()
+            cmd.args.dest_broker = None
+            cmd.args.topic_partition_filter = 'foo'
+            cmd.args.rf_change = True
+            cmd.args.rf_mismatch = True
+            mock_filter.return_value = {('T0', 0)}
+            ct = create_cluster_topology(assignment, brokers)
+            cb = PartitionCountBalancer(ct, cmd.args)
+            cmd.run_command(ct, cb)
+
+            assert cmd.process_assignment.call_count == 1
+            args, _ = cmd.process_assignment.call_args_list[0]
+            assignment = args[0]
+            assert len(assignment) == 1
+            assert set(assignment[('T0', 0)]) == set([1])
+
+    def test_rf_change(self, create_cluster_topology, assignment, brokers):
+        with mock.patch.object(ReplaceBrokerCmd, 'process_assignment'), mock.patch.object(ReplaceBrokerCmd, 'get_topic_filter'):
+            cmd = ReplaceBrokerCmd()
+            cmd.args = self.mock_args()
+            # Remove broker 1
+            cmd.args.source_broker = 1
+            cmd.args.dest_broker = None
+            ct = create_cluster_topology(assignment, brokers)
+            cb = PartitionCountBalancer(ct, cmd.args)
+            # No rf changes allowed -- should fail
+            with pytest.raises(SystemExit):
+                cmd.run_command(ct, cb)
+            assert cmd.process_assignment.call_count == 0
+            # Should still fail even if we set mismatch
+            # Need to recreate cluster_topology since it gets modified by previous
+            ct = create_cluster_topology(assignment, brokers)
+            cmd.args.rf_mismatch = True
+            with pytest.raises(SystemExit):
+                cmd.run_command(ct, cb)
+            assert cmd.process_assignment.call_count == 0
+            # Allow rf changes for entire topic, T0
+            ct = create_cluster_topology(assignment, brokers)
+            cmd.args.rf_change = True
+            cmd.run_command(ct, cb)
+            assert cmd.process_assignment.call_count == 1
+
+    def test_rf_mismatch(self, create_cluster_topology, assignment, brokers):
+        with mock.patch.object(ReplaceBrokerCmd, 'process_assignment'), mock.patch.object(ReplaceBrokerCmd, 'get_topic_filter'):
+            cmd = ReplaceBrokerCmd()
+            cmd.args = self.mock_args()
+            # Remove broker 0
+            cmd.args.source_broker = 0
+            cmd.args.dest_broker = None
+            ct = create_cluster_topology(assignment, brokers)
+            cb = PartitionCountBalancer(ct, cmd.args)
+            # No rf mismatch allowed -- should fail
+            with pytest.raises(SystemExit):
+                cmd.run_command(ct, cb)
+            assert cmd.process_assignment.call_count == 0
+            # Should still fail even if we set rf_change
+            cmd.args.rf_change = True
+            ct = create_cluster_topology(assignment, brokers)
+            with pytest.raises(SystemExit):
+                cmd.run_command(ct, cb)
+            assert cmd.process_assignment.call_count == 0
+            # Allow rf mismatch for T0
+            ct = create_cluster_topology(assignment, brokers)
+            cmd.args.rf_mismatch = True
+            cmd.run_command(ct, cb)
+            assert cmd.process_assignment.call_count == 1


### PR DESCRIPTION
This adds support for removing brokers from replica assignment. We specify a replica removal by having a source-broker with no dest-broker. Replica addition could also be added in a similar way, but I'm gonna leave that for the next PR.

Before it was not possible because the script would do two steps of verification for replacement:

1. Check that the overall replication factor of the topic partitions has not changed. This check can now be skipped with the `--rf-changes` flag
2. Check that the replication factor of topic partitions within the same topic is the same. This check can now be skipped with the `--rf-mismatch` flag.

We also introduce a `--topic-partition-filter` flag, that is a path to some output from `kafka-check`, so that you can focus on fixing offline or specific partitions instead of generating a plan for all of them.

Wrote some unit tests and will be trying this out in dev later today, just want to get the review out first.

A sample invocation to generate a reassignment plan to remove a faulty broker id `0` might be:

`kafka-cluster-manager -t test_cluster --write-to-file reassign_plan.json replace-broker --source-broker 0 --max-leader-changes 5000 --max-partition-movements 5000 --topic-partition-filter topic_partitions.txt --rf-mismatch  --rf-change`

where `topic_partitions.txt` is similar to `kafka-check` output:

```
my_topic:0
other_topic:1
```

While the above command is rather long, it should be much better than relying on adhoc scripts to generate reassignment json files.