### PR TITLE
Add preferred replica election command to generate json files

### DIFF
--- a/kafka_utils/kafka_cluster_manager/cmds/command.py
+++ b/kafka_utils/kafka_cluster_manager/cmds/command.py
@@ -317,3 +317,19 @@ class ClusterManagerCmd(object):
         """Dump proposed json plan to given output file for future usage."""
         with open(proposed_plan_file, 'w') as output:
             json.dump(proposed_layout, output)
+
+    # For use in commands that accept topic filters, e.g. replace-broker and preferred-replica-election
+    def get_topic_filter(self):
+        if self.args.topic_partition_filter is None:
+            self.log.error('Need to specify topic partition filter file')
+            sys.exit(1)
+        filter_set = set()
+        with open(self.args.topic_partition_filter, 'r') as f:
+            for line in f:
+                tokens = line.split(':')
+                if len(tokens) != 2:
+                    self.log.error("Invalid topic partition filter line: %s", line)
+                    sys.exit(1)
+                t_p = (tokens[0].strip(), int(tokens[1].strip()))
+                filter_set.add(t_p)
+        return filter_set

--- a/kafka_utils/kafka_cluster_manager/cmds/preferred_replica_election.py
+++ b/kafka_utils/kafka_cluster_manager/cmds/preferred_replica_election.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+from __future__ import print_function
+
+import json
+import logging
+import sys
+
+from .command import ClusterManagerCmd
+
+
+class PreferredReplicaElectionCmd(ClusterManagerCmd):
+
+    def __init__(self):
+        super(PreferredReplicaElectionCmd, self).__init__()
+        self.log = logging.getLogger(self.__class__.__name__)
+
+    def build_subparser(self, subparsers):
+        subparser = subparsers.add_parser(
+            'preferred-replica-election',
+            description='Generates json files for kafka-preferred-replica-election',
+            help='This command is used to help generate kafka-preferred-replica-election'
+                 ' json files based on input from kafka-check.'
+        )
+        subparser.add_argument(
+            '--topic-partition-filter',
+            type=str,
+            required=True,
+            help='Path to file containing a colon separated list of topic partitions to work on.'
+                 ' This is useful if you only want to operate on a limited set of topic partitions'
+                 ' Observe that kafka-check outputs colon separated lists, after ommitting the first $n'
+                 ' lines e.g. kafka-check offline | tail -n+$N',
+        )
+        return subparser
+
+    def run_command(self, cluster_topology, cluster_balancer):
+        filter_set = self.get_topic_filter()
+        output = {'partitions': []}
+        # Validate the filter_set to check that all of the partitions provided are part of the cluster_topology
+        for t_p in filter_set:
+            if t_p not in cluster_topology.assignment:
+                self.log.error('Topic partition {} from filter not in cluster topology'.format(t_p))
+                sys.exit(1)
+            topic, partition = t_p[0], t_p[1]
+            output['partitions'].append({'topic': topic, 'partition': partition})
+
+        self.log.info('Preferred replica assignment json generated. Run kafka-preferred-replica-election using this json:')
+        print(json.dumps(output))
+
+        if self.args.proposed_plan_file:
+            self.write_json_plan(output, self.args.proposed_plan_file)
+            self.log.info('Saved plan to file {}'.format(self.args.proposed_plan_file))

--- a/kafka_utils/kafka_cluster_manager/cmds/replace.py
+++ b/kafka_utils/kafka_cluster_manager/cmds/replace.py
@@ -92,18 +92,6 @@ class ReplaceBrokerCmd(ClusterManagerCmd):
         )
         return subparser
 
-    def get_topic_filter(self):
-        filter_set = set()
-        with open(self.args.topic_partition_filter, 'r') as f:
-            for line in f:
-                tokens = line.split(':')
-                if len(tokens) != 2:
-                    self.log.error("Invalid topic partition filter line: %s", line)
-                    sys.exit(1)
-                t_p = (tokens[0].strip(), int(tokens[1].strip()))
-                filter_set.add(t_p)
-        return filter_set
-
     def run_command(self, cluster_topology, cluster_balancer):
         if self.args.source_broker == self.args.dest_broker:
             print("Error: Destination broker is same as source broker.")

--- a/kafka_utils/kafka_cluster_manager/main.py
+++ b/kafka_utils/kafka_cluster_manager/main.py
@@ -36,6 +36,7 @@ from kafka_utils.kafka_cluster_manager.cluster_info.replication_group_parser \
 from kafka_utils.kafka_cluster_manager.cluster_info.replication_group_parser \
     import ReplicationGroupParser
 from kafka_utils.kafka_cluster_manager.cmds.decommission import DecommissionCmd
+from kafka_utils.kafka_cluster_manager.cmds.preferred_replica_election import PreferredReplicaElectionCmd
 from kafka_utils.kafka_cluster_manager.cmds.rebalance import RebalanceCmd
 from kafka_utils.kafka_cluster_manager.cmds.replace import ReplaceBrokerCmd
 from kafka_utils.kafka_cluster_manager.cmds.revoke_leadership import RevokeLeadershipCmd
@@ -170,6 +171,7 @@ def parse_args():
     StoreAssignmentsCmd().add_subparser(subparsers)
     ReplaceBrokerCmd().add_subparser(subparsers)
     SetReplicationFactorCmd().add_subparser(subparsers)
+    PreferredReplicaElectionCmd().add_subparser(subparsers)
 
     return parser.parse_args()
 


### PR DESCRIPTION
This command will allow us to easily generate files for `kafka-preferred-replica-election` based on the output of `kafka-check`