### PR TITLE
set_replication_factor command to handle mismatched replication factor partitions

### DIFF
--- a/kafka_utils/kafka_cluster_manager/cmds/command.py
+++ b/kafka_utils/kafka_cluster_manager/cmds/command.py
@@ -104,10 +104,10 @@ class ClusterManagerCmd(object):
     def add_subparser(self, subparsers):
         self.build_subparser(subparsers).set_defaults(command=self.run)
 
-    def execute_plan(self, plan, allow_rf_change=False):
+    def execute_plan(self, plan, allow_rf_change=False, allow_rf_mismatch=False):
         """Save proposed-plan and execute the same if requested."""
         if self.should_execute():
-            result = self.zk.execute_plan(plan, allow_rf_change=allow_rf_change)
+            result = self.zk.execute_plan(plan, allow_rf_change=allow_rf_change, allow_rf_mismatch=allow_rf_mismatch)
             if not result:
                 self.log.error('Plan execution unsuccessful.')
                 sys.exit(1)
@@ -139,7 +139,7 @@ class ClusterManagerCmd(object):
         else:
             return False
 
-    def process_assignment(self, assignment, allow_rf_change=False):
+    def process_assignment(self, assignment, allow_rf_change=False, allow_rf_mismatch=False):
         plan = assignment_to_plan(assignment)
         if self.args.proposed_plan_file:
             self.log.info(
@@ -155,7 +155,7 @@ class ClusterManagerCmd(object):
             'Proposed-plan actions count: %s',
             len(plan['partitions']),
         )
-        self.execute_plan(plan, allow_rf_change=allow_rf_change)
+        self.execute_plan(plan, allow_rf_change=allow_rf_change, allow_rf_mismatch=allow_rf_mismatch)
 
     def get_reduced_assignment(
         self,

--- a/kafka_utils/util/zookeeper.py
+++ b/kafka_utils/util/zookeeper.py
@@ -540,7 +540,7 @@ class ZK:
         )
         self.delete(path, True)
 
-    def execute_plan(self, plan, allow_rf_change=False):
+    def execute_plan(self, plan, allow_rf_change=False, allow_rf_mismatch=False):
         """Submit reassignment plan for execution."""
         reassignment_path = '{admin}/{reassignment_node}'\
             .format(admin=ADMIN_PATH, reassignment_node=REASSIGNMENT_NODE)
@@ -549,7 +549,7 @@ class ZK:
         for partition in plan['partitions']:
             topic_names_from_proposed_plan.add(partition['topic'])
         base_plan = self.get_cluster_plan(topic_names=list(topic_names_from_proposed_plan))
-        if not validate_plan(plan, base_plan, allow_rf_change=allow_rf_change):
+        if not validate_plan(plan, base_plan, allow_rf_change=allow_rf_change, allow_rf_mismatch=allow_rf_mismatch):
             _log.error('Given plan is invalid. Aborting new reassignment plan ... {plan}'.format(plan=plan))
             return False
         # Send proposed-plan to zookeeper


### PR DESCRIPTION
Some manual testing:

Suppose we have a topic with mismatched topic RF like so:
```
baisang@noneofyourbusiness ~/kafka-utils> kafka-info -t test topic test_topic
<...>
Partitions details:
  Partition 0: Total size 0.0B
    Leader <redacted>: Start offset 4, End offset 4, Size 0.0B
    Follower <redacted>: Insync True, End offset 4, Size 0.0B
  Partition 1: Total size 0.0B
    Leader <redacted>: Start offset 0, End offset 0, Size 0.0B
Topic specific configuration:
    None
```
Old set_replication_factor can't handle this situation properly:

```
baisang@noneofyourbusiness ~/kafka-utils> kafka-cluster-manager -t test set_replication_factor --topic test_topic 2
INFO:kazoo.client:Connecting to my_zk:2181
INFO:kazoo.client:Zookeeper connection established, state: CONNECTED
INFO:kafka-zookeeper-manager:Fetching current cluster-topology from Zookeeper...
INFO:SetReplicationFactorCmd:Increasing topic test_topic replication factor from 1 to 2.
INFO:SetReplicationFactorCmd:Total number of actions before reduction: 2.
INFO:SetReplicationFactorCmd:Number of partition changes: 2. Number of leader-only changes: 0
INFO:SetReplicationFactorCmd:Proposed plan assignment {'version': 1, 'partitions': [{'topic': u'test_topic', 'partition': 0, 'replicas': [<redacted>, <redacted>, <redacted>]}, {'topic': u'test_topic', 'partition': 1, 'replicas': [<redacted>, <redacted>]}]}
INFO:SetReplicationFactorCmd:Proposed-plan actions count: 2
INFO:SetReplicationFactorCmd:Proposed plan won't be executed (--apply and confirmation needed).
INFO:kazoo.client:Closing connection to my_zk:2181
INFO:kazoo.client:Zookeeper session lost, state: CLOSED
```
But using the new tool, it can work (observe it requires all of the proper flags passed in):

```
baisang@noneofyourbusiness ~/kafka-utils> ./kafka-cluster-manager -t test --apply set_replication_factor --topic test_topic 2
INFO:kazoo.client:Connecting to my_zk:2181, use_ssl: False
INFO:kazoo.client:Zookeeper connection established, state: CONNECTED
INFO:kafka-zookeeper-manager:Fetching current cluster-topology from Zookeeper...
INFO:SetReplicationFactorCmd:Increasing topic partition test_topic:1 replication factor from 1 to 2.
INFO:SetReplicationFactorCmd:Total number of actions before reduction: 1.
INFO:SetReplicationFactorCmd:Number of partition changes: 1. Number of leader-only changes: 0
INFO:SetReplicationFactorCmd:Proposed plan assignment {'version': 1, 'partitions': [{'topic': 'test_topic', 'partition': 1, 'replicas': [<redacted>, <redacted>]}]}
INFO:SetReplicationFactorCmd:Proposed-plan actions count: 1
Execute Proposed Plan? [yes/no] yes
INFO:kafka-zookeeper-manager:Fetching current cluster-topology from Zookeeper...
ERROR:kafka_utils.util.validation:Mismatch in replication-factor of partitions for topic test_topic
ERROR:kafka_utils.util.validation:Invalid assignment from cluster.
ERROR:kafka-zookeeper-manager:Given plan is invalid. Aborting new reassignment plan ... {'version': 1, 'partitions': [{'topic': 'test_topic', 'partition': 1, 'replicas': [<redacted>, <redacted>]}]}
ERROR:SetReplicationFactorCmd:Plan execution unsuccessful.
INFO:kazoo.client:Closing connection to my_zk:2181
INFO:kazoo.client:Zookeeper session lost, state: CLOSED



baisang@noneofyourbusiness ~/kafka-utils> ./kafka-cluster-manager -t test --apply set_replication_factor --topic test_topic 2 --rf-mismatch
INFO:kazoo.client:Connecting to my_zk:2181, use_ssl: False
INFO:kazoo.client:Zookeeper connection established, state: CONNECTED
INFO:kafka-zookeeper-manager:Fetching current cluster-topology from Zookeeper...
INFO:SetReplicationFactorCmd:Increasing topic partition test_topic:1 replication factor from 1 to 2.
INFO:SetReplicationFactorCmd:Total number of actions before reduction: 1.
INFO:SetReplicationFactorCmd:Number of partition changes: 1. Number of leader-only changes: 0
INFO:SetReplicationFactorCmd:Proposed plan assignment {'version': 1, 'partitions': [{'topic': 'test_topic', 'partition': 1, 'replicas': [<redacted>, <redacted>]}]}
INFO:SetReplicationFactorCmd:Proposed-plan actions count: 1
Execute Proposed Plan? [yes/no] yes
INFO:kafka-zookeeper-manager:Fetching current cluster-topology from Zookeeper...
INFO:kafka-zookeeper-manager:Sending plan to Zookeeper...
INFO:kafka-zookeeper-manager:Re-assign partitions node in Zookeeper updated successfully with {'version': 1, 'partitions': [{'topic': 'test_topic', 'partition': 1, 'replicas': [<redacted>, <redacted>]}]}
INFO:SetReplicationFactorCmd:Plan sent to zookeeper for reassignment successfully.
INFO:kazoo.client:Closing connection to my_zk:2181
INFO:kazoo.client:Zookeeper session lost, state: CLOSED
```