### PR TITLE
Bump to latest `kafka-python` version...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     ],
     install_requires=[
         "humanfriendly>=4.8",
-        "kafka-python>=1.3.2,<1.5.0",
+        "kafka-python>=2.0.1,<3.0.0",
         "kazoo>=2.0,<3.0.0",
         "PyYAML>3.10",
         "pytz>=2014.1",


### PR DESCRIPTION
A number of commands were added to the `KafkaAdminClient` including describing topics, configs, etc but they all require `kafka-python` >= 2.0.0. 2.0.1 was a patch release to fix a minor bug, so bumped to that.

This release also dropped a bunch of deprecated code, so partly opening this PR to see what the test coverage level is and how much stuff needs additional fixes.

At a minimum this PR should also bump the version in `requirements*.txt`... 