### PR TITLE
Allow using Kafka AdminClient for kafka-consumer-manager commands

### DIFF
--- a/kafka_utils/kafka_consumer_manager/commands/copy_group.py
+++ b/kafka_utils/kafka_consumer_manager/commands/copy_group.py
@@ -72,6 +72,7 @@ class CopyGroup(OffsetManagerBase):
             args.partitions,
             cluster_config,
             client,
+            use_admin_client=args.use_admin_client,
         )
 
         cls.copy_group_kafka(

--- a/kafka_utils/kafka_consumer_manager/commands/delete_group.py
+++ b/kafka_utils/kafka_consumer_manager/commands/delete_group.py
@@ -53,6 +53,7 @@ class DeleteGroup(OffsetWriter):
             None,
             cluster_config,
             client,
+            use_admin_client=args.use_admin_client,
         )
         cls.delete_group_kafka(client, args.groupid, topics_dict)
 

--- a/kafka_utils/kafka_consumer_manager/commands/list_groups.py
+++ b/kafka_utils/kafka_consumer_manager/commands/list_groups.py
@@ -55,7 +55,8 @@ class ListGroups(OffsetManagerBase):
     def run(cls, args, cluster_config):
         groups = set()
         kafka_groups = cls.get_kafka_groups(
-            cluster_config, args.use_admin_client,
+            cluster_config,
+            args.use_admin_client,
         )
         if kafka_groups:
             groups.update(kafka_groups)

--- a/kafka_utils/kafka_consumer_manager/commands/list_groups.py
+++ b/kafka_utils/kafka_consumer_manager/commands/list_groups.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 from .offset_manager import OffsetManagerBase
-from kafka_utils.kafka_consumer_manager.util import KafkaGroupReader
+from kafka_utils.kafka_consumer_manager.util import get_kafka_group_reader
 
 
 class ListGroups(OffsetManagerBase):
@@ -31,10 +31,11 @@ class ListGroups(OffsetManagerBase):
         parser_list_groups.set_defaults(command=cls.run)
 
     @classmethod
-    def get_kafka_groups(cls, cluster_config):
+    def get_kafka_groups(cls, cluster_config, use_admin_client=False):
         '''Get the group_id of groups committed into Kafka.'''
-        kafka_group_reader = KafkaGroupReader(cluster_config)
-        return list(kafka_group_reader.read_groups().keys())
+        kafka_group_reader = get_kafka_group_reader(cluster_config, use_admin_client)
+        groups_and_topics = kafka_group_reader.read_groups(list_only=True)
+        return list(groups_and_topics.keys())
 
     @classmethod
     def print_groups(cls, groups, cluster_config):
@@ -53,7 +54,9 @@ class ListGroups(OffsetManagerBase):
     @classmethod
     def run(cls, args, cluster_config):
         groups = set()
-        kafka_groups = cls.get_kafka_groups(cluster_config)
+        kafka_groups = cls.get_kafka_groups(
+            cluster_config, args.use_admin_client,
+        )
         if kafka_groups:
             groups.update(kafka_groups)
 

--- a/kafka_utils/kafka_consumer_manager/commands/list_topics.py
+++ b/kafka_utils/kafka_consumer_manager/commands/list_topics.py
@@ -55,6 +55,7 @@ class ListTopics(OffsetManagerBase):
             cluster_config=cluster_config,
             client=client,
             fail_on_error=False,
+            use_admin_client=args.use_admin_client,
         )
         if not topics_dict:
             print("Consumer Group ID: {group} does not exist.".format(

--- a/kafka_utils/kafka_consumer_manager/commands/offset_advance.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_advance.py
@@ -74,6 +74,7 @@ class OffsetAdvance(OffsetWriter):
             cluster_config,
             client,
             force=args.force,
+            use_admin_client=args.use_admin_client,
         )
         try:
             advance_consumer_offsets(

--- a/kafka_utils/kafka_consumer_manager/commands/offset_get.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_get.py
@@ -96,6 +96,7 @@ class OffsetGet(OffsetManagerBase):
             cluster_config=cluster_config,
             client=client,
             quiet=args.json,
+            use_admin_client=args.use_admin_client,
         )
 
         consumer_offsets_metadata = cls.get_offsets(

--- a/kafka_utils/kafka_consumer_manager/commands/offset_manager.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_manager.py
@@ -21,7 +21,7 @@ import sys
 import six
 from kazoo.exceptions import NoNodeError
 
-from kafka_utils.kafka_consumer_manager.util import KafkaGroupReader
+from kafka_utils.kafka_consumer_manager.util import get_kafka_group_reader
 from kafka_utils.kafka_consumer_manager.util import prompt_user_input
 from kafka_utils.util.zookeeper import ZK
 
@@ -33,8 +33,11 @@ class OffsetManagerBase(object):
         cls,
         cluster_config,
         groupid,
+        use_admin_client=False,
     ):
-        return cls.get_topics_for_group_from_kafka(cluster_config, groupid)
+        return cls.get_topics_for_group_from_kafka(
+            cluster_config, groupid, use_admin_client,
+        )
 
     @classmethod
     def preprocess_args(
@@ -47,6 +50,7 @@ class OffsetManagerBase(object):
         fail_on_error=True,
         quiet=False,
         topics=None,
+        use_admin_client=False,
     ):
         if topics and partitions:
             print(
@@ -80,6 +84,7 @@ class OffsetManagerBase(object):
         subscribed_topics = cls.get_topics_from_consumer_group_id(
             cluster_config,
             groupid,
+            use_admin_client,
         )
         topics_dict = {}
 
@@ -142,8 +147,11 @@ class OffsetManagerBase(object):
         cls,
         cluster_config,
         groupid,
+        use_admin_client=False,
     ):
-        kafka_group_reader = KafkaGroupReader(cluster_config)
+        kafka_group_reader = get_kafka_group_reader(
+            cluster_config, use_admin_client,
+        )
         try:
             group_topics = kafka_group_reader.read_group(groupid)
         except KeyError:

--- a/kafka_utils/kafka_consumer_manager/commands/offset_manager.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_manager.py
@@ -217,6 +217,7 @@ class OffsetWriter(OffsetManagerBase):
         fail_on_error=True,
         force=False,
         topics=None,
+        use_admin_client=False,
     ):
         topics_dict = super(OffsetWriter, cls).preprocess_args(
             groupid,
@@ -226,6 +227,7 @@ class OffsetWriter(OffsetManagerBase):
             client,
             fail_on_error=(fail_on_error and not force),
             topics=topics,
+            use_admin_client=use_admin_client,
         )
 
         if not topics_dict and force:

--- a/kafka_utils/kafka_consumer_manager/commands/offset_rewind.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_rewind.py
@@ -74,6 +74,7 @@ class OffsetRewind(OffsetWriter):
             cluster_config,
             client,
             force=args.force,
+            use_admin_client=args.use_admin_client,
         )
         try:
             rewind_consumer_offsets(

--- a/kafka_utils/kafka_consumer_manager/commands/offset_save.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_save.py
@@ -81,6 +81,7 @@ class OffsetSave(OffsetManagerBase):
             partitions=args.partitions,
             cluster_config=cluster_config,
             client=client,
+            use_admin_client=args.use_admin_client,
         )
         try:
             consumer_offsets_metadata = get_consumer_offsets_metadata(

--- a/kafka_utils/kafka_consumer_manager/commands/rename_group.py
+++ b/kafka_utils/kafka_consumer_manager/commands/rename_group.py
@@ -67,6 +67,7 @@ class RenameGroup(OffsetManagerBase):
             partitions=None,
             cluster_config=cluster_config,
             client=client,
+            use_admin_client=args.use_admin_client,
         )
         cls.rename_group(
             client,

--- a/kafka_utils/kafka_consumer_manager/commands/unsubscribe_topics.py
+++ b/kafka_utils/kafka_consumer_manager/commands/unsubscribe_topics.py
@@ -80,6 +80,7 @@ class UnsubscribeTopics(OffsetWriter):
             cluster_config,
             client,
             topics=args.topics,
+            use_admin_client=args.use_admin_client,
         )
 
         topics = args.topics if args.topics else ([args.topic] if args.topic else [])

--- a/kafka_utils/kafka_consumer_manager/main.py
+++ b/kafka_utils/kafka_consumer_manager/main.py
@@ -83,7 +83,7 @@ def parse_args():
     parser.add_argument(
         "--use-admin-client", action="store_true",
         help="Use the Kafka AdminClient interface to fetch consumer "
-        "group offsets."
+        "group offsets for quicker performance."
     )
     subparsers = parser.add_subparsers()
 

--- a/kafka_utils/kafka_consumer_manager/main.py
+++ b/kafka_utils/kafka_consumer_manager/main.py
@@ -80,6 +80,11 @@ def parse_args():
         action='store_true',
         help='Show DEBUG level logging',
     )
+    parser.add_argument(
+        "--use-admin-client", action="store_true",
+        help="Use the Kafka AdminClient interface to fetch consumer "
+        "group offsets."
+    )
     subparsers = parser.add_subparsers()
 
     OffsetGet.add_parser(subparsers)

--- a/tests/kafka_consumer_manager/test_list_groups.py
+++ b/tests/kafka_consumer_manager/test_list_groups.py
@@ -28,7 +28,7 @@ class TestListGroups(object):
     def mock_kafka_info(self):
         with mock.patch(
             "kafka_utils.kafka_consumer_manager."
-            "commands.list_groups.KafkaGroupReader",
+            "commands.list_groups.get_kafka_group_reader",
             autospec=True
         ) as mock_kafka_reader:
             yield mock_kafka_reader


### PR DESCRIPTION
Reading the __consumer_offsets topic at every run is slow and can add
unwanted load on a Kafka cluster. The AdminClient allows to get the list
of consumer groups and the list of topics from a group id in constance
time.

This is currently a feature flag to keep backwards compatibility, but
will later be enabled by default.

--use-admin-client