### PR TITLE
Allow kafka-rolling-restart script to be executed in clusters with SSL our SASL enabled

### DIFF
--- a/tests/util/zookeeper_test.py
+++ b/tests/util/zookeeper_test.py
@@ -402,29 +402,14 @@ class TestZK(object):
             )
 
             zk.get = mock.Mock(
-                return_value=("""
-                {
-                    "endpoints":[
-                        "SSL://broker:9093"
-                    ],
-                    "host":null
-                }
-                """, None)
+                return_value=(b'{"endpoints":["SSL://broker:9093"],"host":null}', None)
             )
             expected = {1: {'host': 'broker'}}
             actual = zk.get_brokers()
             assert actual[1]['host'] == expected[1]['host']
 
             zk.get = mock.Mock(
-                return_value=("""
-                {
-                    "endpoints":[
-                        "INTERNAL://broker:9093",
-                        "EXTERNAL://broker:9093"
-                    ],
-                    "host":null
-                }
-                """, None)
+                return_value=(b'{"endpoints":["INTERNAL://broker:9093","EXTERNAL://broker:9093"],"host":null}', None)
             )
             expected = {1: {'host': 'broker'}}
             actual = zk.get_brokers()
@@ -437,14 +422,7 @@ class TestZK(object):
             )
 
             zk.get = mock.Mock(
-                return_value=("""
-                {
-                    "endpoints":[
-                        "PLAINTEXTSASL://broker:9093"
-                    ],
-                    "host":null
-                }
-                """, None)
+                return_value=(b'{"endpoints":["PLAINTEXTSASL://broker:9093"],"host":null}', None)
             )
             expected = {1: {'host': 'broker'}}
             actual = zk.get_brokers()
@@ -457,12 +435,7 @@ class TestZK(object):
             )
 
             zk.get = mock.Mock(
-                return_value=("""
-                {
-                    "endpoints":[],
-                    "host":"broker"
-                }
-                """, None)
+                return_value=(b'{"endpoints":[],"host":"broker"}', None)
             )
             expected = {1: {'host': 'broker'}}
             actual = zk.get_brokers()

--- a/tests/util/zookeeper_test.py
+++ b/tests/util/zookeeper_test.py
@@ -394,3 +394,76 @@ class TestZK(object):
             expected_with_no_node_error = {}
             zk.get_children.assert_called_with("/brokers/ids")
             assert actual_with_no_node_error == expected_with_no_node_error
+
+    def test_get_brokers_with_metadata_for_ssl(self, mock_client):
+        with ZK(self.cluster_config) as zk:
+            zk.get_children = mock.Mock(
+                return_value=[1],
+            )
+
+            zk.get = mock.Mock(
+                return_value=("""
+                {
+                    "endpoints":[
+                        "SSL://broker:9093"
+                    ],
+                    "host":null
+                }
+                """, None)
+            )
+            expected = {1: {'host': 'broker'}}
+            actual = zk.get_brokers()
+            assert actual[1]['host'] == expected[1]['host']
+
+            zk.get = mock.Mock(
+                return_value=("""
+                {
+                    "endpoints":[
+                        "INTERNAL://broker:9093",
+                        "EXTERNAL://broker:9093"
+                    ],
+                    "host":null
+                }
+                """, None)
+            )
+            expected = {1: {'host': 'broker'}}
+            actual = zk.get_brokers()
+            assert actual[1]['host'] == expected[1]['host']
+
+    def test_get_brokers_with_metadata_for_sasl(self, mock_client):
+        with ZK(self.cluster_config) as zk:
+            zk.get_children = mock.Mock(
+                return_value=[1],
+            )
+
+            zk.get = mock.Mock(
+                return_value=("""
+                {
+                    "endpoints":[
+                        "PLAINTEXTSASL://broker:9093"
+                    ],
+                    "host":null
+                }
+                """, None)
+            )
+            expected = {1: {'host': 'broker'}}
+            actual = zk.get_brokers()
+            assert actual[1]['host'] == expected[1]['host']
+
+    def test_get_brokers_with_metadata_for_plaintext(self, mock_client):
+        with ZK(self.cluster_config) as zk:
+            zk.get_children = mock.Mock(
+                return_value=[1],
+            )
+
+            zk.get = mock.Mock(
+                return_value=("""
+                {
+                    "endpoints":[],
+                    "host":"broker"
+                }
+                """, None)
+            )
+            expected = {1: {'host': 'broker'}}
+            actual = zk.get_brokers()
+            assert actual[1]['host'] == expected[1]['host']


### PR DESCRIPTION
The goal of this PR is to be able to perform rolling restart in a Kafka Cluster using SSL or SASL

For plaintext broker when you get metadata from Zookeeper, the result is like that (this result is used to get broker's hostname):

```
{
   "jmx_port":-1,
   "timestamp":"1312312312",
   "endpoints":[],
   "host":"broker-hostname:9092",
   "version":2,
   "port":-1
}
````

for broker using SSL is like that:

```
{
   "listener_security_protocol_map":{
      "SSL":"SSL"
   },
   "endpoints":[
      "SSL://broker-hostname:9093"
   ],
   "jmx_port":-1,
   "host":null,
   "timestamp":"1584750310126",
   "port":-1,
   "version":4
}
```

for broker using SSL with internal and external mapping is like that:

```
{
   "listener_security_protocol_map":{
      "SSL":"SSL"
   },
   "endpoints":[
      "INTERNAL://broker-hostname:9093",
      "EXTERNAL://broker-hostname:9093"
   ],
   "jmx_port":-1,
   "host":null,
   "timestamp":"1584750310126",
   "port":-1,
   "version":4
}
```

for broker using SASL is like that:

```
{
   "listener_security_protocol_map":{
      "SSL":"SSL"
   },
   "endpoints":[
      "PLAINTEXTSASL://foo.mycorp.com:9092"
   ],
   "jmx_port":-1,
   "host":null,
   "timestamp":"1584750310126",
   "port":-1,
   "version":4
}
```

in order to be able to handle these result, this PR changes get_broker_metadata method to
handle these outputs
