### PR TITLE
Allow dynamic import to find the child-most class

### DIFF
--- a/kafka_utils/util/utils.py
+++ b/kafka_utils/util/utils.py
@@ -65,11 +65,13 @@ def child_class(class_types, base_class):
         # If more than one class is a subclass of `base_class`
         # It is possible that one or more classes are subclasses of another
         # class (see example above).
-        # Recursively find the child-most class.
+        # Recursively find the child-most class. Break ties by returning any
+        # child-most class.
         for c in subclasses:
             child = child_class(subclasses, c)
             if child is not None:
                 return child
+        return subclasses.pop()
 
 
 def dynamic_import(module_full_name, base_class):

--- a/kafka_utils/util/utils.py
+++ b/kafka_utils/util/utils.py
@@ -34,9 +34,48 @@ def get_module(module_full_name):
         return importlib.import_module(module_full_name)
 
 
+def child_class(class_types, base_class):
+    """
+    Find the child-most class of `base_class`.
+
+    Examples:
+        class A:
+            pass
+
+        class B(A):
+            pass
+
+        class C(B):
+            pass
+
+        child_class([A, B, C], A) = C
+    """
+    subclasses = set()
+    for class_type in class_types:
+        if class_type is base_class:
+            continue
+        if issubclass(class_type, base_class):
+            subclasses.add(class_type)
+
+    if len(subclasses) == 0:
+        return None
+    elif len(subclasses) == 1:
+        return subclasses.pop()
+    else:
+        # If more than one class is a subclass of `base_class`
+        # It is possible that one or more classes are subclasses of another
+        # class (see example above).
+        # Recursively find the child-most class.
+        for c in subclasses:
+            child = child_class(subclasses, c)
+            if child is not None:
+                return child
+
+
 def dynamic_import(module_full_name, base_class):
     module = get_module(module_full_name)
-    for _, class_type in inspect.getmembers(module, inspect.isclass):
-        if (issubclass(class_type, base_class) and
-                class_type is not base_class):
-            return class_type
+    class_types = [
+        class_type
+        for _, class_type in inspect.getmembers(module, inspect.isclass)
+    ]
+    return child_class(class_types, base_class)

--- a/tests/util/util_test.py
+++ b/tests/util/util_test.py
@@ -24,6 +24,7 @@ from kafka_utils.util import positive_nonzero_int
 from kafka_utils.util import tuple_alter
 from kafka_utils.util import tuple_remove
 from kafka_utils.util import tuple_replace
+from kafka_utils.util.utils import child_class
 
 
 def test_tuple_alter():
@@ -92,3 +93,17 @@ def test_positive_float_not_float():
 def test_positive_float_negative_float():
     with pytest.raises(ArgumentTypeError):
         positive_float('-1.45')
+
+
+def test_child_class():
+    class A(object):
+        pass
+
+    class B(A):
+        pass
+
+    class C(B):
+        pass
+
+    assert child_class([A, B, C], A) == C
+    assert child_class([A, B], A) == B

--- a/tests/util/util_test.py
+++ b/tests/util/util_test.py
@@ -105,5 +105,9 @@ def test_child_class():
     class C(B):
         pass
 
+    class D(A):
+        pass
+
     assert child_class([A, B, C], A) == C
     assert child_class([A, B], A) == B
+    assert child_class([A, B, D], A) in {B, D}


### PR DESCRIPTION
When using dynamic import to find a child class of `base_class`, if two
classes match the criteria (e.g: class A, class B(A), class C(B)),
dynamic_import would return B instead of C as it stops at the first
class found in the package that is a subclass of A.

This commit changes the behaviour to return the child-most class.