### PR TITLE
Fix missing rf_mismatch arg in process_assignment call

### DIFF
--- a/kafka_utils/kafka_cluster_manager/cmds/replace.py
+++ b/kafka_utils/kafka_cluster_manager/cmds/replace.py
@@ -134,7 +134,7 @@ class ReplaceBrokerCmd(ClusterManagerCmd):
             self.args.max_leader_changes,
         )
         if reduced_assignment:
-            self.process_assignment(reduced_assignment, allow_rf_change=self.args.rf_change)
+            self.process_assignment(reduced_assignment, allow_rf_change=self.args.rf_change, allow_rf_mismatch=self.args.rf_mismatch)
         else:
             self.log.info("Broker already replaced. No more replicas in source broker.")
             print("Broker already replaced. No more replicas in source broker.")

--- a/kafka_utils/kafka_corruption_check/main.py
+++ b/kafka_utils/kafka_corruption_check/main.py
@@ -41,18 +41,18 @@ INVALID_MESSAGE_REGEX = re.compile(".* isvalid: false")
 INVALID_BYTES_REGEX = re.compile(".*invalid bytes")
 
 
-def chunks(l, n):
-    """Yield successive n-sized chunks from l.
+def chunks(input, n):
+    """Yield successive n-sized chunks from input.
 
-    :param l: the list
-    :type l: list
+    :param input: the provided list
+    :type input: list
     :param n: the size of the chunk
     :type n: int
     :returns: a sequence of n-sized chunks of the input list
     :rtype: generator
     """
-    for i in range(0, len(l), n):
-        yield l[i:i + n]
+    for i in range(0, len(input), n):
+        yield input[i:i + n]
 
 
 def ssh_client(host):

--- a/kafka_utils/util/validation.py
+++ b/kafka_utils/util/validation.py
@@ -190,10 +190,7 @@ def _validate_format(plan):
 
     # Empty partitions
     if not plan['partitions']:
-        _log.error(
-            '"partitions" list found empty"'
-            .format(version=plan['partitions']),
-        )
+        _log.error('"partitions" list found empty"')
         return False
 
     # Invalid partitions type

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 flake8
+importlib-metadata==0.23
 ipdb==0.10.3
 ipython==4.2.0
 ipython-genutils==0.1.0

--- a/tests/acceptance/steps/min_isr.py
+++ b/tests/acceptance/steps/min_isr.py
@@ -66,6 +66,5 @@ def step_impl5(context):
 @then(u'CRITICAL min_isr will be printed')
 def step_impl6(context):
     error_msg = ("CRITICAL: 1 partition(s) have the number of "
-                 "replicas in sync that is lower than the specified min ISR.\n").format(
-        topic=context.topic)
+                 "replicas in sync that is lower than the specified min ISR.\n")
     assert context.min_isr_out == error_msg, context.min_isr_out


### PR DESCRIPTION
## Context
This will allow us to (actually) ignore errors of the form `Mismatch in replication-factor of partitions`. This is particularly useful when issuing commands to recover from incidents related to https://issues.apache.org/jira/browse/KAFKA-8733.

## Changes
- Fix missing rf_mismatch arg in process_assignment
- Fix version conflict in requirements-dev
- Address various `flake8` issues

## Testing Done
`make test` passes