### PR TITLE
Pin cryptography version to 3.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+cryptography==3.0
 flake8
 importlib-metadata==0.23
 ipdb==0.10.3


### PR DESCRIPTION
The current version of `cryptography` being pulled in the Jenkins build is `3.2`, which uses `setuptools v49.2.1`, which is not compatible with `py27`. Pinning `cryptography` to `3.0` prevents this from happening and this should get the Jenkins build to succeed.

### Testing
`make test` now passes on a Jenkins host