### PR TITLE
Use srv-configs for discovery only if it exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Kafka-Utils runs on python2.7 and python3.
 
 Kafka-Utils reads cluster configuration needed to access Kafka clusters from yaml files. Each cluster is identified by *type* and *name*.
 Multiple clusters of the same type should be listed in the same `type.yaml` file.
-The yaml files are read from `$KAFKA_DISCOVERY_DIR`, `$HOME/.kafka_discovery` and `/nail/srv/configs/kafka_discovery_configs`, the former overrides the latter.
+The yaml files are read from `$KAFKA_DISCOVERY_DIR`, `$HOME/.kafka_discovery` and `/nail/srv/configs/kafka_discovery_configs`, the former overrides the latter. If the `/nail/srv/configs/kafka_discovery_configs` directory does not exist then the `/etc/kafka_discovery` directory is used instead.
 
 
 Sample configuration for `sample_type` cluster at `/nail/srv/configs/kafka_discovery_configs/sample_type.yaml`

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Kafka-Utils runs on python2.7 and python3.
 
 Kafka-Utils reads cluster configuration needed to access Kafka clusters from yaml files. Each cluster is identified by *type* and *name*.
 Multiple clusters of the same type should be listed in the same `type.yaml` file.
-The yaml files are read from `$KAFKA_DISCOVERY_DIR`, `$HOME/.kafka_discovery` and `/nail/srv/configs/kafka_discovery_configs`, the former overrides the latter. If the `/nail/srv/configs/kafka_discovery_configs` directory does not exist then the `/etc/kafka_discovery` directory is used instead.
+The yaml files are read from `$KAFKA_DISCOVERY_DIR`, `$HOME/.kafka_discovery` and `/nail/srv/configs/kafka_discovery_configs`, the former overrides the latter.
+If the `/nail/srv/configs/kafka_discovery_configs` directory does not exist then the `/etc/kafka_discovery` directory is used instead.
 
 
 Sample configuration for `sample_type` cluster at `/nail/srv/configs/kafka_discovery_configs/sample_type.yaml`

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -5,7 +5,8 @@ Kafka-Utils reads the cluster configuration needed to access Kafka clusters from
 Each cluster is identified by *type* and *name*.
 Multiple clusters of the same type should be listed in the same `type.yaml` file.
 The yaml files are read from :code:`$KAFKA_DISCOVERY_DIR`, :code:`$HOME/.kafka_discovery` and :code:`/nail/srv/configs/kafka_discovery_configs`,
-the former overrides the latter.
+the former overrides the latter. If the :code:`/nail/srv/configs/kafka_discovery_configs` directory does not exist then the :code:`/etc/kafka_discovery` directory is used instead.
+
 
 Sample configuration for :code:`sample_type` cluster at :code:`/nail/srv/configs/kafka_discovery_configs/sample_type.yaml`
 
@@ -31,4 +32,4 @@ For example the kafka-cluster-manager command:
     $ kafka-cluster-manager --cluster-type sample_type stats
 
 will pick up default cluster `cluster-1` from the local_config at /nail/srv/configs/kafka_discovery_configs/sample_type.yaml to display
-statistics of default kafka-configuration.
+statistics of default kafka-configuration. If the /nail/srv/configs/kafka_discovery_configs directory does not exist then the /etc/kafka_discovery directory is used instead.

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -5,7 +5,8 @@ Kafka-Utils reads the cluster configuration needed to access Kafka clusters from
 Each cluster is identified by *type* and *name*.
 Multiple clusters of the same type should be listed in the same `type.yaml` file.
 The yaml files are read from :code:`$KAFKA_DISCOVERY_DIR`, :code:`$HOME/.kafka_discovery` and :code:`/nail/srv/configs/kafka_discovery_configs`,
-the former overrides the latter. If the :code:`/nail/srv/configs/kafka_discovery_configs` directory does not exist then the :code:`/etc/kafka_discovery` directory is used instead.
+the former overrides the latter.
+If the :code:`/nail/srv/configs/kafka_discovery_configs` directory does not exist then the :code:`/etc/kafka_discovery` directory is used instead.
 
 
 Sample configuration for :code:`sample_type` cluster at :code:`/nail/srv/configs/kafka_discovery_configs/sample_type.yaml`
@@ -32,4 +33,5 @@ For example the kafka-cluster-manager command:
     $ kafka-cluster-manager --cluster-type sample_type stats
 
 will pick up default cluster `cluster-1` from the local_config at /nail/srv/configs/kafka_discovery_configs/sample_type.yaml to display
-statistics of default kafka-configuration. If the /nail/srv/configs/kafka_discovery_configs directory does not exist then the /etc/kafka_discovery directory is used instead.
+statistics of default kafka-configuration.
+If the /nail/srv/configs/kafka_discovery_configs directory does not exist then the /etc/kafka_discovery directory is used instead.

--- a/kafka_utils/main.py
+++ b/kafka_utils/main.py
@@ -43,7 +43,7 @@ def parse_args():
         type=str,
         help='Path of the directory containing the <cluster_type>.yaml config.'
         ' Default try: '
-        '$KAFKA_DISCOVERY_DIR, $HOME/.kafka_discovery, /nail/srv/configs/kafka_discovery_configs',
+        '$KAFKA_DISCOVERY_DIR, $HOME/.kafka_discovery, /nail/srv/configs/kafka_discovery_configs, /etc/kafka_discovery',
     )
 
     return parser.parse_args()

--- a/kafka_utils/util/config.py
+++ b/kafka_utils/util/config.py
@@ -32,6 +32,11 @@ DEFAULT_KAFKA_TOPOLOGY_BASE_PATH = '/nail/srv/configs/kafka_discovery_configs'
 HOME_OVERRIDE = '.kafka_discovery'
 
 
+# Use /etc/kafka_discovery if /nail/srv/configs/kafka_discovery does not exist
+if not os.path.isdir(DEFAULT_KAFKA_TOPOLOGY_BASE_PATH):
+    DEFAULT_KAFKA_TOPOLOGY_BASE_PATH = '/etc/kafka_discovery'
+
+
 class ClusterConfig(
     namedtuple(
         'ClusterConfig',


### PR DESCRIPTION
This is a slight change to https://github.com/Yelp/kafka-utils/pull/262 and we now only use the srv-configs directory if it exists on the host, otherwise we continue using the `/etc/kafka_discovery` directory for cluster discovery configuration files.

I will release this with a patch version bump.