### PR TITLE
Change the default Kafka discovery config directory back to /etc/kafka_discovery

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+3.9.0 (November 13, 2020)
+----------------------------
+* Change the default Kafka discovery config directory back to /etc/kafka_discovery
+
 3.8.2 (November 9, 2020)
 ----------------------------
 * Conditionally choose between /nail/srv/configs/kafka_discovery_configs and /etc/kafka_discovery for default directory to read Kafka discovery files depending on if the former exists

--- a/README.md
+++ b/README.md
@@ -9,11 +9,10 @@ Kafka-Utils runs on python2.7 and python3.
 
 Kafka-Utils reads cluster configuration needed to access Kafka clusters from yaml files. Each cluster is identified by *type* and *name*.
 Multiple clusters of the same type should be listed in the same `type.yaml` file.
-The yaml files are read from `$KAFKA_DISCOVERY_DIR`, `$HOME/.kafka_discovery` and `/nail/srv/configs/kafka_discovery_configs`, the former overrides the latter.
-If the `/nail/srv/configs/kafka_discovery_configs` directory does not exist then the `/etc/kafka_discovery` directory is used instead.
+The yaml files are read from `$KAFKA_DISCOVERY_DIR`, `$HOME/.kafka_discovery` and `/etc/kafka_discovery`, the former overrides the latter.
 
 
-Sample configuration for `sample_type` cluster at `/nail/srv/configs/kafka_discovery_configs/sample_type.yaml`
+Sample configuration for `sample_type` cluster at `/etc/kafka_discovery/sample_type.yaml`
 
 ```yaml
 ---

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -4,12 +4,10 @@ Configuration
 Kafka-Utils reads the cluster configuration needed to access Kafka clusters from yaml files.
 Each cluster is identified by *type* and *name*.
 Multiple clusters of the same type should be listed in the same `type.yaml` file.
-The yaml files are read from :code:`$KAFKA_DISCOVERY_DIR`, :code:`$HOME/.kafka_discovery` and :code:`/nail/srv/configs/kafka_discovery_configs`,
+The yaml files are read from :code:`$KAFKA_DISCOVERY_DIR`, :code:`$HOME/.kafka_discovery` and :code:`/etc/kafka_discovery`,
 the former overrides the latter.
-If the :code:`/nail/srv/configs/kafka_discovery_configs` directory does not exist then the :code:`/etc/kafka_discovery` directory is used instead.
 
-
-Sample configuration for :code:`sample_type` cluster at :code:`/nail/srv/configs/kafka_discovery_configs/sample_type.yaml`
+Sample configuration for :code:`sample_type` cluster at :code:`/etc/kafka_discovery/sample_type.yaml`
 
 .. code-block:: yaml
 
@@ -32,6 +30,5 @@ For example the kafka-cluster-manager command:
 
     $ kafka-cluster-manager --cluster-type sample_type stats
 
-will pick up default cluster `cluster-1` from the local_config at /nail/srv/configs/kafka_discovery_configs/sample_type.yaml to display
+will pick up default cluster `cluster-1` from the local_config at /etc/kafka_discovery/sample_type.yaml to display
 statistics of default kafka-configuration.
-If the /nail/srv/configs/kafka_discovery_configs directory does not exist then the /etc/kafka_discovery directory is used instead.

--- a/kafka_utils/main.py
+++ b/kafka_utils/main.py
@@ -43,7 +43,7 @@ def parse_args():
         type=str,
         help='Path of the directory containing the <cluster_type>.yaml config.'
         ' Default try: '
-        '$KAFKA_DISCOVERY_DIR, $HOME/.kafka_discovery, /nail/srv/configs/kafka_discovery_configs, /etc/kafka_discovery',
+        '$KAFKA_DISCOVERY_DIR, $HOME/.kafka_discovery, /etc/kafka_discovery',
     )
 
     return parser.parse_args()

--- a/kafka_utils/util/config.py
+++ b/kafka_utils/util/config.py
@@ -28,13 +28,8 @@ from kafka_utils.util.error import InvalidConfigurationError
 from kafka_utils.util.error import MissingConfigurationError
 
 
-DEFAULT_KAFKA_TOPOLOGY_BASE_PATH = '/nail/srv/configs/kafka_discovery_configs'
+DEFAULT_KAFKA_TOPOLOGY_BASE_PATH = '/etc/kafka_discovery'
 HOME_OVERRIDE = '.kafka_discovery'
-
-
-# Use /etc/kafka_discovery if /nail/srv/configs/kafka_discovery does not exist
-if not os.path.isdir(DEFAULT_KAFKA_TOPOLOGY_BASE_PATH):
-    DEFAULT_KAFKA_TOPOLOGY_BASE_PATH = '/etc/kafka_discovery'
 
 
 class ClusterConfig(

--- a/tests/util/config_test.py
+++ b/tests/util/config_test.py
@@ -295,8 +295,8 @@ class TestTopologyConfig(object):
             topology.get_cluster_by_name('does-not-exist')
 
     def test___eq__(self, mock_yaml):
-        topology1 = TopologyConfiguration("mykafka", "/nail/srv/configs/kafka_discovery_configs")
-        topology2 = TopologyConfiguration("mykafka", "/nail/srv/configs/kafka_discovery_configs")
+        topology1 = TopologyConfiguration("mykafka", "/etc/kafka_discovery")
+        topology2 = TopologyConfiguration("mykafka", "/etc/kafka_discovery")
         assert topology1 == topology2
 
         topology1 = TopologyConfiguration("mykafka")
@@ -304,8 +304,8 @@ class TestTopologyConfig(object):
         assert topology1 == topology2
 
     def test___ne__(self, mock_yaml):
-        topology1 = TopologyConfiguration("mykafka", "/nail/srv/configs/kafka_discovery_configs")
-        topology2 = TopologyConfiguration("somethingelse", "/nail/srv/configs/kafka_discovery_configs")
+        topology1 = TopologyConfiguration("mykafka", "/etc/kafka_discovery")
+        topology2 = TopologyConfiguration("somethingelse", "/etc/kafka_discovery")
         assert topology1 != topology2
 
         topology1 = TopologyConfiguration("mykafka")


### PR DESCRIPTION
## Description
This reverts the changes made in https://github.com/Yelp/kafka-utils/pull/265 and https://github.com/Yelp/kafka-utils/pull/262 since we now use a cron job to rsync files from the srv-configs directory.

## Testing Done
`make test` passes

## Ticket
KAFKA-30532

## Release Strategy
minor version release (`v3.9.0`)