### PR TITLE
Drop official py27 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 2.7
   - 3.6
 sudo: required
 services:

--- a/Makefile
+++ b/Makefile
@@ -18,15 +18,15 @@ clean:
 	make -C docs clean
 
 test:
-	tox -e py{27,36}-unittest
+	tox -e py36-unittest
 
 acceptance: acceptance10 acceptance11
 
 acceptance10:
-	tox -e py{27,36}-kafka10-dockeritest
+	tox -e py36-kafka10-dockeritest
 
 acceptance11:
-	tox -e py{27,36}-kafka11-dockeritest
+	tox -e py36-kafka11-dockeritest
 
 coverage:
 	tox -e coverage

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 # Kafka-Utils
 
 A suite of python tools to interact and manage Apache Kafka clusters.
-Kafka-Utils runs on python2.7 and python3.
+Kafka-Utils runs on and python3.6 and above.
+
+Python 2 support ended in January 2021.
 
 ## Configuration
 

--- a/docker/itest/Dockerfile
+++ b/docker/itest/Dockerfile
@@ -37,8 +37,6 @@ RUN apt-get update \
     build-essential \
     libffi-dev \
     libssl-dev \
-    python2.7 \
-    python2.7-dev \
     python3.6 \
     python3.6-dev \
     python-pip \

--- a/setup.py
+++ b/setup.py
@@ -64,8 +64,6 @@ setup(
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Environment :: Console",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,36}-unittest, py{27,36}-kafka{10,11}-dockeritest
+envlist = py36-unittest, py36-kafka{10,11}-dockeritest
 # The Makefile and .travis.yml override the index server to the public one when
 # running outside of Yelp.
 indexserver =
@@ -9,7 +9,6 @@ tox_pip_extensions_ext_venv_update = true
 
 [travis]
 python =
-  py27: py27-unittest, py27-kafka{10,11}-dockeritest
   py36: py36-unittest, py36-kafka{10,11}-dockeritest
 
 [testenv]
@@ -19,7 +18,6 @@ deps =
 whitelist_externals = /bin/bash
 passenv = ITEST_PYTHON_FACTOR KAFKA_VERSION ACCEPTANCE_TAGS
 setenv =
-    py27: ITEST_PYTHON_FACTOR = py27
     py36: ITEST_PYTHON_FACTOR = py36
     kafka10: KAFKA_VERSION = 0.10.1.1
     kafka10: ACCEPTANCE_TAGS = ~kafka11

--- a/tox_acceptance.ini
+++ b/tox_acceptance.ini
@@ -1,12 +1,11 @@
 [tox]
-envlist = py{27,36}-unittest, py{27,36}-kafka{10,11}-dockeritest
+envlist = py36-unittest, py36-kafka{10,11}-dockeritest
 tox_pip_extensions_ext_pip_custom_platform = true
 tox_pip_extensions_ext_venv_update = true
 distdir = {toxworkdir}/dist_acceptance
 
 [travis]
 python =
-  py27: py27-kafka{10,11}-dockeritest
   py36: py36-kafka{10,11}-dockeritest
 
 [testenv]
@@ -18,7 +17,6 @@ deps =
 whitelist_externals = /bin/bash
 passenv = ITEST_PYTHON_FACTOR KAFKA_VERSION ACCEPTANCE_TAGS
 setenv =
-    py27: ITEST_PYTHON_FACTOR = py27
     py36: ITEST_PYTHON_FACTOR = py36
     kafka10: KAFKA_VERSION = 0.10.1.1
     kafka10: ACCEPTANCE_TAGS = ~kafka11


### PR DESCRIPTION
Python2.7 hit End-of-Life in January 2020. Although we have historically tried our best to support Python 2 beyond this date, various other package maintainers have discontinued their support (and explicitly disallow it).

I propose dropping support here (as part of a campaign to fix our open-source Travis build pipeline) but not actively blocking installation into py2. However, we will be unable to test against Python 2 from now on.