### PR TITLE
Increase upper pin and introduce lower pin on paramiko

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "PyYAML>3.10",
         "pytz>=2014.1",
         "requests-futures>0.9.0",
-        "paramiko<2.5.0",
+        "paramiko>1.8.0,<3.0.0",
         "requests<3.0.0",
         "retrying",
         "six>=1.10.0",

--- a/tox_acceptance.ini
+++ b/tox_acceptance.ini
@@ -1,5 +1,7 @@
+# this file is run via a Docker container
+# see docker/itest/run_tests.sh for more details
 [tox]
-envlist = py{27,36}-unittest, py{27,36}-kafka{10,11}-dockeritest
+envlist = py{27,36}-kafka{10,11}-dockeritest
 tox_pip_extensions_ext_pip_custom_platform = true
 tox_pip_extensions_ext_venv_update = true
 distdir = {toxworkdir}/dist_acceptance


### PR DESCRIPTION
Paramiko needs a lower version (https://github.com/Yelp/kafka-utils/issues/146) and we can also allow newer versions of Paramiko.

## Testing Done
`make test` passes (with newer paramiko version)

## Release Plan
I'll have to fix the Pypi.org release mechanism (https://github.com/Yelp/kafka-utils/issues/258) but I plan to do a patch release for this particular change.