### PR TITLE
Fix gh acceptance build

### DIFF
--- a/.github/workflows/kafka-utils-ci.yml
+++ b/.github/workflows/kafka-utils-ci.yml
@@ -2,7 +2,7 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: kafka-utils-ci
-on: [pull_request]
+on: [pull_request, release]
 
 jobs:
   tox:

--- a/.github/workflows/kafka-utils-ci.yml
+++ b/.github/workflows/kafka-utils-ci.yml
@@ -8,6 +8,7 @@ jobs:
   tox:
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         toxenv:
           - py36-unittest

--- a/.github/workflows/kafka-utils-ci.yml
+++ b/.github/workflows/kafka-utils-ci.yml
@@ -2,7 +2,7 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: kafka-utils-ci
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   tox:

--- a/docker/itest/Dockerfile
+++ b/docker/itest/Dockerfile
@@ -30,10 +30,7 @@ RUN /tmp/download-kafka.sh && tar xfz /tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSIO
 ENV PATH="$PATH:$KAFKA_HOME/bin"
 
 # Install Python
-RUN apt-get update \
-  && add-apt-repository -y ppa:deadsnakes/ppa \
-  && apt-get update \
-  && apt-get install -y \
+RUN apt-get install -y \
     build-essential \
     libffi-dev \
     libssl-dev \

--- a/docker/itest/Dockerfile
+++ b/docker/itest/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:18.04
 MAINTAINER Team Data Streams Core <data-streams-core@yelp.com>
+ENV DEBIAN_FRONTEND noninteractive
 
 ARG KAFKA_VERSION
 # We need to install Java and Kafka in order to use Kafka CLI. The Kafka server
@@ -13,7 +14,7 @@ RUN apt-get update && \
     openjdk-8-jdk
 
 # Install Kafka.
-RUN apt-get update && apt-get install -y \
+RUN apt-get install -y \
     unzip \
     wget \
     curl \

--- a/docker/itest/Dockerfile
+++ b/docker/itest/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 MAINTAINER Team Data Streams Core <data-streams-core@yelp.com>
 
 ARG KAFKA_VERSION

--- a/docker/itest/Dockerfile
+++ b/docker/itest/Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get install -y \
     python2.7-dev \
     python3.6 \
     python3.6-dev \
+    python3-distutils \
     python-pip \
     python-pkg-resources \
     python-setuptools

--- a/docker/itest/Dockerfile
+++ b/docker/itest/Dockerfile
@@ -45,8 +45,7 @@ RUN apt-get update \
     python-pkg-resources \
     python-setuptools
 
-RUN pip install -U pip
-RUN pip install tox more-itertools==4.2.0
+RUN pip install tox
 
 COPY run_tests.sh /scripts/run_tests.sh
 RUN chmod 755 /scripts/run_tests.sh

--- a/docker/kafka/Dockerfile
+++ b/docker/kafka/Dockerfile
@@ -1,5 +1,6 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 MAINTAINER Team Data Streams Core <data-streams-core@yelp.com>
+ENV DEBIAN_FRONTEND noninteractive
 
 ARG KAFKA_VERSION
 

--- a/docker/zookeeper/Dockerfile
+++ b/docker/zookeeper/Dockerfile
@@ -1,5 +1,6 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 MAINTAINER Team Data Streams Core <data-streams-core@yelp.com>
+ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get -y install zookeeper
 


### PR DESCRIPTION
The only problems happened in our acceptance test suite, where we run everything from Docker containers. The main issue happened with how we were setting up our testing suite's virtual environment (in `docker/test/Dockerfile`) but I also took this chance to migrate to Ubuntu Bionic (18.04) and clean up some other sub-optimal things in our Dockerfiles.

Note that the GH action change is meant to reduce duplicate test runs when creating/updating a CR (see #270) and also ensure that all 3 test suites can run independently - so you still get test results for all 3 even if one fails.

This doesn't change the actual package we distribute, just how we test it.