### PR TITLE
Add more descriptive error message when encountering UnknownMemberIdError while advancing offsets 

### DIFF
--- a/kafka_utils/kafka_consumer_manager/commands/offset_advance.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_advance.py
@@ -18,6 +18,8 @@ from __future__ import unicode_literals
 
 import sys
 
+from kafka.errors import UnknownMemberIdError
+
 from .offset_manager import OffsetWriter
 from kafka_utils.util.client import KafkaToolClient
 from kafka_utils.util.offsets import advance_consumer_offsets
@@ -86,6 +88,14 @@ class OffsetAdvance(OffsetWriter):
             print(
                 "Error: Badly formatted input, please re-run command ",
                 "with --help option.", file=sys.stderr
+            )
+            raise
+        except UnknownMemberIdError:
+            print(
+                "Unable to unsubscribe group '{group_name}' from topic '{topic_name}'. \
+                    You must ensure none of the consumers with this consumer group id are running before \
+                    trying to unsubscribe a consumer group with offsets stored in Kafka. Try stopping all \
+                    of your consumers.".format(group_name=args.groupid, topic_name=args.topic),
             )
             raise
 

--- a/kafka_utils/kafka_consumer_manager/commands/offset_advance.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_advance.py
@@ -94,7 +94,7 @@ class OffsetAdvance(OffsetWriter):
             print(
                 "Unable to unsubscribe group '{group_name}' from topic '{topic_name}'. \
                     You must ensure none of the consumers with this consumer group id are running before \
-                    trying to unsubscribe a consumer group with offsets stored in Kafka. Try stopping all \
+                    trying to advance the offsets stored in Kafka for this consumer group. Try stopping all \
                     of your consumers.".format(group_name=args.groupid, topic_name=args.topic),
             )
             raise

--- a/kafka_utils/kafka_consumer_manager/commands/offset_advance.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_advance.py
@@ -92,7 +92,7 @@ class OffsetAdvance(OffsetWriter):
             raise
         except UnknownMemberIdError:
             print(
-                "Unable to unsubscribe group '{group_name}' from topic '{topic_name}'. \
+                "Unable to advance offsets for group '{group_name}' from topic '{topic_name}'. \
                     You must ensure none of the consumers with this consumer group id are running before \
                     trying to advance the offsets stored in Kafka for this consumer group. Try stopping all \
                     of your consumers.".format(group_name=args.groupid, topic_name=args.topic),


### PR DESCRIPTION
## Problem
If an `UnknownMemberIdError` is encountered while using `kafka-consumer-manager offset_advance`, users will see an error of the following form:

```
kafka.errors.UnknownMemberIdError: [Error 25] UnknownMemberIdError: OffsetCommitResponsePayload(topic='some_kafka_topic', partition=0, error=25)
```

This can be a bit opaque for users who are not familiar with the internals of Kafka.

## Solution
We give users a more practical error message which instructs them to stop their consumer prior to attempting to advance offsets.

## Verification
tests pass

## Release Plan
`patch` release 