### PR TITLE
add kafka-manual-throttle to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "scripts/kafka-utils",
         "scripts/kafka-check",
         "scripts/kafka-corruption-check",
+        "scripts/kafka-manual-throttle",
     ],
     install_requires=[
         "humanfriendly>=4.8",


### PR DESCRIPTION
We have been using kafka-utils for years now and I've noticed that kafka-manual-throttle script isn't installed as part of setup.py.  Adding here so that people can make advantage of it.
