### PR TITLE
KAFKA-32352: Add replication factor mismatch topics command

### DIFF
--- a/kafka_utils/kafka_cluster_manager/cmds/replication_factor_mismatch_topics.py
+++ b/kafka_utils/kafka_cluster_manager/cmds/replication_factor_mismatch_topics.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+
+from .command import ClusterManagerCmd
+
+
+class ReplicationFactorMismatchTopicsCmd(ClusterManagerCmd):
+
+    def __init__(self):
+        super(ReplicationFactorMismatchTopicsCmd, self).__init__()
+
+    def build_subparser(self, subparsers):
+        subparser = subparsers.add_parser(
+            'replication-factor-mismatch-topics',
+            description='Get topics with replication factor mismatch among its partitions.',
+            help='This command is used to find which topics have partitions with replicas less than the configured '
+                 'replication factor of the topic.',
+        )
+        return subparser
+
+    def _print_mismatch_topics(self, rf_mismatch_topics):
+        print("{mismatch_count} topic(s) with replication factor mismatch found".format(mismatch_count=len(rf_mismatch_topics)))
+        for topic in rf_mismatch_topics:
+            print("\tTopic ID: {topic_id}".format(topic_id=topic.id))
+            print("\t\tPartitions: {partitions}".format(partitions=topic.partitions))
+
+    def run_command(self, ct, cluster_balancer):
+        rf_mismatch_topics = []
+
+        for topic in ct.topics.values():
+            # Kafka considers first partition's replica count as the replication factor of the topic
+            # So that, any of the partitions having a different replica count means there is a mismatch
+            # https://github.com/apache/kafka/blob/77a89fcf8d7fa01831683327727f11f4bed97319/core/src/main/scala/kafka/admin/TopicCommand.scala#L286
+            partitions_replication_count = {len(partition.replicas) for partition in topic.partitions}
+
+            if len(partitions_replication_count) > 1:
+                rf_mismatch_topics.append(topic)
+
+        self._print_mismatch_topics(rf_mismatch_topics)

--- a/kafka_utils/kafka_cluster_manager/main.py
+++ b/kafka_utils/kafka_cluster_manager/main.py
@@ -39,6 +39,7 @@ from kafka_utils.kafka_cluster_manager.cmds.decommission import DecommissionCmd
 from kafka_utils.kafka_cluster_manager.cmds.preferred_replica_election import PreferredReplicaElectionCmd
 from kafka_utils.kafka_cluster_manager.cmds.rebalance import RebalanceCmd
 from kafka_utils.kafka_cluster_manager.cmds.replace import ReplaceBrokerCmd
+from kafka_utils.kafka_cluster_manager.cmds.replication_factor_mismatch_topics import ReplicationFactorMismatchTopicsCmd
 from kafka_utils.kafka_cluster_manager.cmds.revoke_leadership import RevokeLeadershipCmd
 from kafka_utils.kafka_cluster_manager.cmds.set_replication_factor import SetReplicationFactorCmd
 from kafka_utils.kafka_cluster_manager.cmds.stats import StatsCmd
@@ -172,6 +173,7 @@ def parse_args():
     ReplaceBrokerCmd().add_subparser(subparsers)
     SetReplicationFactorCmd().add_subparser(subparsers)
     PreferredReplicaElectionCmd().add_subparser(subparsers)
+    ReplicationFactorMismatchTopicsCmd().add_subparser(subparsers)
 
     return parser.parse_args()
 

--- a/tests/kafka_cluster_manager/cmds/replication_factor_mismatch_topics_test.py
+++ b/tests/kafka_cluster_manager/cmds/replication_factor_mismatch_topics_test.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+
+from argparse import Namespace
+
+import mock
+
+from kafka_utils.kafka_cluster_manager.cluster_info.partition_count_balancer \
+    import PartitionCountBalancer
+from kafka_utils.kafka_cluster_manager.cmds.replication_factor_mismatch_topics \
+    import ReplicationFactorMismatchTopicsCmd
+
+
+def init_cmd():
+    cmd = ReplicationFactorMismatchTopicsCmd()
+    cmd.args = mock.Mock(spec=Namespace)
+    cmd._print_mismatch_topics = mock.Mock()
+
+    return cmd
+
+
+def get_assignment_and_brokers(rf_mismatch=False):
+    assignment = {
+        (u'T0', 0): ['0', '1', '2'] if rf_mismatch else ['0', '1', '2', '3', '4'],
+        (u'T0', 1): ['0', '1', '2', '3', '4'],
+        (u'T1', 2): ['0', '1'],
+        (u'T1', 3): ['0', '1'],
+    }
+    brokers = {
+        '0': {'host': 'host2'},
+        '1': {'host': 'host2'},
+        '2': {'host': 'host3'},
+        '3': {'host': 'host4'},
+        '4': {'host': 'host5'},
+    }
+
+    return assignment, brokers
+
+
+class TestReplicationFactorMismatchTopicsCmd(object):
+
+    def test_no_rf_mismatch(self, create_cluster_topology):
+        assignment, brokers = get_assignment_and_brokers(rf_mismatch=False)
+
+        cmd = init_cmd()
+
+        ct = create_cluster_topology(assignment, brokers)
+        cb = PartitionCountBalancer(ct, cmd.args)
+        cmd.run_command(ct, cb)
+
+        assert cmd._print_mismatch_topics.call_count == 1
+        cmd._print_mismatch_topics.assert_called_with([])
+
+    def test_rf_mismatch(self, create_cluster_topology):
+        assignment, brokers = get_assignment_and_brokers(rf_mismatch=True)
+
+        cmd = init_cmd()
+
+        ct = create_cluster_topology(assignment, brokers)
+        cb = PartitionCountBalancer(ct, cmd.args)
+        cmd.run_command(ct, cb)
+
+        assert cmd._print_mismatch_topics.call_count == 1
+
+        rf_mismatch_topics = cmd._print_mismatch_topics.call_args.args[0]
+        assert len(rf_mismatch_topics) == 1
+        assert rf_mismatch_topics[0].id == u'T0'


### PR DESCRIPTION
## Problem
Right now there is no way of finding which topic partitions have number of replicas less than the configured replication factor of the topic.

## Solution
We add a new command to show the user which topics has replication factor mismatch among its partitions.

![rf-mismatch](https://user-images.githubusercontent.com/48732802/121009340-f33a5500-c78b-11eb-9f74-2658306963a0.png)

## Verification
tests pass

## Release Plan
`minor` release 