### PR TITLE
Fix build failing because of dependencies conflict

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+PyYAML<4,>=3.10 # pre-commit 0.8.0 doesnt support PyYAML>=6.0 and docker-compose 1.7.0 requires PyYAML<4,>=3.10
 cryptography==3.0
 flake8
 importlib-metadata==0.23

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 cryptography==3.0
 flake8
 importlib-metadata==0.23
-ipdb==0.10.3
+ipdb==0.13
 ipython==4.2.0
 ipython-genutils==0.1.0
 mock

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ cryptography==3.0
 flake8
 importlib-metadata==0.23
 ipdb==0.13
-ipython==4.2.0
+ipython==5.1.0
 ipython-genutils==0.1.0
 mock
 pre-commit==0.8.0


### PR DESCRIPTION
Changes:
- Updated `ipdb` and `ipython` as they failed to install because of incompatibility issues with `setuptools==58.3.0`
- Pinned PyYAML in `requirements-dev.txt` as `PyYAML==6.0` is not compatible with `pre-commit==0.8.0` and `docker-compose==1.7.0`