### PR TITLE
When a decommission node is empty, don't crash on max/min functions

### DIFF
--- a/kafka_utils/kafka_cluster_manager/cmds/decommission.py
+++ b/kafka_utils/kafka_cluster_manager/cmds/decommission.py
@@ -108,13 +108,11 @@ class DecommissionCmd(ClusterManagerCmd):
             partitions_to_move.update(cluster_topology.brokers[broker].partitions)
 
         largest_size = max(
-            partition.size
-            for partition in partitions_to_move
+            [partition.size for partition in partitions_to_move] or (1, )
         )
 
         smallest_size = min(
-            partition.size
-            for partition in partitions_to_move
+            [partition.size for partition in partitions_to_move] or (0, )
         )
 
         if self.args.auto_max_movement_size:

--- a/tests/kafka_cluster_manager/decommission_test.py
+++ b/tests/kafka_cluster_manager/decommission_test.py
@@ -1,0 +1,31 @@
+from __future__ import unicode_literals
+
+from argparse import Namespace
+
+import mock
+import pytest
+
+from kafka_utils.kafka_cluster_manager.cluster_info \
+    .partition_count_balancer import PartitionCountBalancer
+from kafka_utils.kafka_cluster_manager.cmds import decommission
+from tests.kafka_cluster_manager.helper import broker_range
+
+
+@pytest.fixture
+def command_instance():
+    cmd = decommission.DecommissionCmd()
+    cmd.args = mock.Mock(spec=Namespace)
+    cmd.args.force_progress = False
+    cmd.args.broker_ids = []
+    cmd.args.auto_max_movement_size = True
+    return cmd
+
+
+def test_decommission_no_partitions_to_move(command_instance, create_cluster_topology):
+    cluster_one_broker_empty = create_cluster_topology(
+        assignment={('topic', 0): [0, 1]},
+        brokers=broker_range(3),
+    )
+    command_instance.args.brokers_ids = [2]
+    balancer = PartitionCountBalancer(cluster_one_broker_empty, command_instance.args)
+    command_instance.run_command(cluster_one_broker_empty, balancer)

--- a/tests/kafka_cluster_manager/decommission_test.py
+++ b/tests/kafka_cluster_manager/decommission_test.py
@@ -18,6 +18,8 @@ def command_instance():
     cmd.args.force_progress = False
     cmd.args.broker_ids = []
     cmd.args.auto_max_movement_size = True
+    cmd.args.max_partition_movements = 10
+    cmd.args.max_leader_changes = 10
     return cmd
 
 


### PR DESCRIPTION
If a broker is being decommissioned and it's already empty, we don't have any need to move other topics. Thus, `partitions_to_move` is an empty set.

Currently, the code will crash with an error:
```
[2021-11-09 15:36:05,992] [CRITICAL:main] Uncaught exception:
Traceback (most recent call last):
...
  File "<>/site-packages/kafka_utils/kafka_cluster_manager/cmds/decommission.py", line 112, in run_command
    for partition in partitions_to_move
ValueError: max() arg is an empty sequence
```
I added a unit test to reproduce this issue (it failed without these changes), and it passes now.

My understanding is that if the `partitions_to_move` is empty, then `self.args.max_movement_size ` being 1 doesn't have any impact.

## Release Plan
Patch version release 