### PR TITLE
Fix internal build failing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
+repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks.git
-    sha: 29bf11d13689a0a9a895c41eb3591c7e942d377d
+    rev: v2.2.3
     hooks:
     -   id: check-added-large-files
     -   id: check-merge-conflict
@@ -11,7 +12,7 @@
         args: ["--ignore=W504,E501"]
 
 -   repo: https://github.com/asottile/reorder_python_imports.git
-    sha: f3dfe379d2ea341c6cf54d926d4585b35dea9251
+    rev: v1.9.0
     hooks:
     -   id: reorder-python-imports
         files: .*\.py$

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,6 @@
-PyYAML<4,>=3.10 # pre-commit 0.8.0 doesnt support PyYAML>=6.0 and docker-compose 1.7.0 requires PyYAML<4,>=3.10
 cryptography==3.0
 flake8
 importlib-metadata==0.23
-ipdb==0.13
-ipython==5.1.0
-ipython-genutils==0.1.0
 mock
 pre-commit==0.8.0
 pytest==3.9.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ cryptography==3.0
 flake8
 importlib-metadata==0.23
 mock
-pre-commit==0.8.0
+pre-commit==1.14.4
 pytest==3.9.3
 setuptools==40.0.0
 tox-pip-extensions==1.2.1


### PR DESCRIPTION
Changes in requirements-dev:
- Removed `ipdb`, `ipython` dependencies.
- Removed `PyYAML` (it will still get installed by pre-commit(`PyYAML==6.0`), then overwritten when tox installs docker-compose (`PyYAML==3.13`).
- Updated `pre-commit` version to 1.14.4 to make it compatible with`PyYAML==6.0`.