### PR TITLE
Add type annotations part 1

### DIFF
--- a/kafka_utils/kafka_check/commands/command.py
+++ b/kafka_utils/kafka_check/commands/command.py
@@ -11,9 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+import argparse
+from typing import Any
+from typing import cast
+
 from kafka_utils.kafka_check import status_code
 from kafka_utils.kafka_check.status_code import prepare_terminate_message
 from kafka_utils.kafka_check.status_code import terminate
+from kafka_utils.util.config import ClusterConfig
 from kafka_utils.util.zookeeper import ZK
 
 
@@ -27,7 +34,7 @@ class KafkaCheckCmd:
         self.args = None
         self.zk = None
 
-    def build_subparser(self, subparsers):
+    def build_subparser(self, subparsers: Any) -> Any:
         """Build the command subparser.
 
         :param subparsers: argpars subparsers
@@ -35,14 +42,14 @@ class KafkaCheckCmd:
         """
         raise NotImplementedError("Implement in subclass")
 
-    def run_command(self):
+    def run_command(self) -> tuple[int, dict[str, Any]]:
         """Implement the command logic.
         When run_command is called cluster_config, args, and zk are already
         initialized.
         """
         raise NotImplementedError("Implement in subclass")
 
-    def run(self, cluster_config, args):
+    def run(self, cluster_config: ClusterConfig, args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         self.cluster_config = cluster_config
         self.args = args
         with ZK(self.cluster_config) as self.zk:
@@ -51,48 +58,48 @@ class KafkaCheckCmd:
             if args.controller_only and not is_controller(self.zk, args.broker_id):
                 terminate(
                     status_code.OK,
-                    prepare_terminate_message(
+                    cast(dict[str, Any], prepare_terminate_message(
                         'Broker {} is not the controller, nothing to check'
                         .format(args.broker_id),
-                    ),
+                    )),
                     args.json,
                 )
             if args.first_broker_only and not broker_ids:
                 terminate(
                     status_code.OK,
-                    prepare_terminate_message(
+                    cast(dict[str, Any], prepare_terminate_message(
                         'No brokers detected, nothing to check'
-                    ),
+                    )),
                     args.json,
                 )
             if args.first_broker_only and not is_first_broker(broker_ids, args.broker_id):
                 terminate(
                     status_code.OK,
-                    prepare_terminate_message(
+                    cast(dict[str, Any], prepare_terminate_message(
                         'Broker {} has not the lowest id, nothing to check'
                         .format(args.broker_id),
-                    ),
+                    )),
                     args.json,
                 )
             return self.run_command()
 
-    def add_subparser(self, subparsers):
+    def add_subparser(self, subparsers: Any) -> None:
         self.build_subparser(subparsers).set_defaults(command=self.run)
 
 
-def is_controller(zk, broker_id):
+def is_controller(zk: ZK, broker_id: int) -> bool:
     """Returns true if the specified broker_id is the controller of the cluster,
     false otherwise.
     """
     return broker_id == zk.get_json('/controller').get('brokerid')
 
 
-def get_broker_ids(zk):
+def get_broker_ids(zk) -> list[int]:
     """Returns a list of integers for broker ids"""
     return list(zk.get_brokers())
 
 
-def is_first_broker(broker_ids, broker_id):
+def is_first_broker(broker_ids: list[int], broker_id: int) -> bool:
     """Returns true if broker_id is the lowest broker id in the cluster, false otherwise."""
     if not broker_ids:
         return False

--- a/kafka_utils/kafka_check/commands/min_isr.py
+++ b/kafka_utils/kafka_check/commands/min_isr.py
@@ -78,10 +78,10 @@ class PartitionDict(TypedDict):
     isr: int
     min_isr: int
     topic: str
-    partition: str
+    partition: int
 
 
-def _process_metadata_response(topics: dict[str, dict[str, PartitionMetadata]], zk: ZK, default_min_isr: int) -> list[PartitionDict]:
+def _process_metadata_response(topics: dict[str, dict[int, PartitionMetadata]], zk: ZK, default_min_isr: int) -> list[PartitionDict]:
     """Returns not in sync partitions."""
     not_in_sync_partitions: list[PartitionDict] = []
     for topic_name, partitions in topics.items():

--- a/kafka_utils/kafka_check/commands/offline.py
+++ b/kafka_utils/kafka_check/commands/offline.py
@@ -11,8 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 import itertools
 import sys
+from typing import Any
 
 from kafka_utils.kafka_check import status_code
 from kafka_utils.kafka_check.commands.command import KafkaCheckCmd
@@ -22,7 +25,7 @@ from kafka_utils.util.metadata import LEADER_NOT_AVAILABLE_ERROR
 
 class OfflineCmd(KafkaCheckCmd):
 
-    def build_subparser(self, subparsers):
+    def build_subparser(self, subparsers: Any) -> Any:
         subparser = subparsers.add_parser(
             'offline',
             description='Check offline partitions on the specified broker',
@@ -32,7 +35,7 @@ class OfflineCmd(KafkaCheckCmd):
 
         return subparser
 
-    def run_command(self):
+    def run_command(self) -> tuple[int, dict[str, Any]]:
         """Checks the number of offline partitions"""
         offline = get_topic_partition_with_error(
             self.cluster_config,
@@ -44,9 +47,9 @@ class OfflineCmd(KafkaCheckCmd):
         return errcode, out
 
 
-def _prepare_output(partitions, verbose, head_limit):
+def _prepare_output(partitions: list[tuple[str, str]], verbose: bool, head_limit: int) -> dict[str, Any]:
     """Returns dict with 'raw' and 'message' keys filled."""
-    out = {}
+    out: dict[str, Any] = {}
     partitions_count = len(partitions)
     out['raw'] = {
         'offline_count': partitions_count,

--- a/kafka_utils/kafka_check/commands/offline.py
+++ b/kafka_utils/kafka_check/commands/offline.py
@@ -47,7 +47,7 @@ class OfflineCmd(KafkaCheckCmd):
         return errcode, out
 
 
-def _prepare_output(partitions: list[tuple[str, str]], verbose: bool, head_limit: int) -> dict[str, Any]:
+def _prepare_output(partitions: list[tuple[str, int]], verbose: bool, head_limit: int) -> dict[str, Any]:
     """Returns dict with 'raw' and 'message' keys filled."""
     out: dict[str, Any] = {}
     partitions_count = len(partitions)

--- a/kafka_utils/kafka_check/commands/replica_unavailability.py
+++ b/kafka_utils/kafka_check/commands/replica_unavailability.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 import itertools
+from typing import Any
 
 from kafka_utils.kafka_check import status_code
 from kafka_utils.kafka_check.commands.command import KafkaCheckCmd
@@ -21,7 +24,7 @@ from kafka_utils.util.metadata import REPLICA_NOT_AVAILABLE_ERROR
 
 class ReplicaUnavailabilityCmd(KafkaCheckCmd):
 
-    def build_subparser(self, subparsers):
+    def build_subparser(self, subparsers: Any) -> Any:
         subparser = subparsers.add_parser(
             'replica_unavailability',
             description='Check availability of replicas for all brokers in cluster.',
@@ -30,7 +33,7 @@ class ReplicaUnavailabilityCmd(KafkaCheckCmd):
         )
         return subparser
 
-    def run_command(self):
+    def run_command(self) -> tuple[int, dict[str, Any]]:
         """replica_unavailability command, checks number of replicas not available
         for communication over all brokers in the Kafka cluster."""
         fetch_unavailable_brokers = True
@@ -49,10 +52,10 @@ class ReplicaUnavailabilityCmd(KafkaCheckCmd):
         return errcode, out
 
 
-def _prepare_output(partitions, unavailable_brokers, verbose, head_limit):
+def _prepare_output(partitions: list[tuple[int, int]], unavailable_brokers: list[str], verbose: bool, head_limit: int) -> dict[str, Any]:
     """Returns dict with 'raw' and 'message' keys filled."""
     partitions_count = len(partitions)
-    out = {}
+    out: dict[str, Any] = {}
     out['raw'] = {
         'replica_unavailability_count': partitions_count,
     }

--- a/kafka_utils/kafka_check/commands/replica_unavailability.py
+++ b/kafka_utils/kafka_check/commands/replica_unavailability.py
@@ -52,7 +52,7 @@ class ReplicaUnavailabilityCmd(KafkaCheckCmd):
         return errcode, out
 
 
-def _prepare_output(partitions: list[tuple[int, int]], unavailable_brokers: list[str], verbose: bool, head_limit: int) -> dict[str, Any]:
+def _prepare_output(partitions: list[tuple[str, int]], unavailable_brokers: list[int], verbose: bool, head_limit: int) -> dict[str, Any]:
     """Returns dict with 'raw' and 'message' keys filled."""
     partitions_count = len(partitions)
     out: dict[str, Any] = {}

--- a/kafka_utils/kafka_check/main.py
+++ b/kafka_utils/kafka_check/main.py
@@ -15,8 +15,12 @@
 Kafka checks module.
 Each check is separated subcommand for kafka-check.
 """
+from __future__ import annotations
+
 import argparse
 import logging
+from typing import Any
+from typing import cast
 
 from kafka_utils.kafka_check import status_code
 from kafka_utils.kafka_check.commands.min_isr import MinIsrCmd
@@ -30,7 +34,7 @@ from kafka_utils.util import config
 from kafka_utils.util.error import ConfigurationError
 
 
-def convert_to_broker_id(string):
+def convert_to_broker_id(string: str) -> int:
     """Convert string to kafka broker_id."""
     error_msg = f'Positive integer or -1 required, {string} given.'
     try:
@@ -42,7 +46,7 @@ def convert_to_broker_id(string):
     return value
 
 
-def parse_args():
+def parse_args() -> argparse.Namespace:
     """Parse the command line arguments."""
     parser = argparse.ArgumentParser(
         description='Check kafka current status',
@@ -122,13 +126,13 @@ def parse_args():
     return parser.parse_args()
 
 
-def validate_args(args):
+def validate_args(args: argparse.Namespace) -> None:
     if args.controller_only and args.first_broker_only:
         terminate(
             status_code.WARNING,
-            prepare_terminate_message(
+            cast(dict[str, Any], prepare_terminate_message(
                 "Only one of controller_only and first_broker_only should be used",
-            ),
+            )),
             args.json,
         )
 
@@ -136,7 +140,7 @@ def validate_args(args):
         if args.broker_id is None:
             terminate(
                 status_code.WARNING,
-                prepare_terminate_message("broker_id is not specified"),
+                cast(dict[str, Any], prepare_terminate_message("broker_id is not specified")),
                 args.json,
             )
         elif args.broker_id == -1:
@@ -145,19 +149,19 @@ def validate_args(args):
             except Exception as e:
                 terminate(
                     status_code.WARNING,
-                    prepare_terminate_message(f"{e}"),
+                    cast(dict[str, Any], prepare_terminate_message(f"{e}")),
                     args.json,
                 )
 
     if args.head != -1 and not args.verbose:
         terminate(
             status_code.WARNING,
-            prepare_terminate_message("--head option works only as addition to --verbose option"),
+            cast(dict[str, Any], prepare_terminate_message("--head option works only as addition to --verbose option")),
             args.json,
         )
 
 
-def run():
+def run() -> None:
     """Verify command-line arguments and run commands"""
     args = parse_args()
     validate_args(args)
@@ -176,7 +180,7 @@ def run():
     except ConfigurationError as e:
         terminate(
             status_code.CRITICAL,
-            prepare_terminate_message(f"ConfigurationError {e}"),
+            cast(dict[str, Any], prepare_terminate_message(f"ConfigurationError {e}")),
             args.json,
         )
 

--- a/kafka_utils/kafka_check/metadata_file.py
+++ b/kafka_utils/kafka_check/metadata_file.py
@@ -1,4 +1,9 @@
-def _parse_meta_properties_file(content):
+from __future__ import annotations
+
+from typing import TextIO
+
+
+def _parse_meta_properties_file(content: TextIO) -> int | None:
     for line in content:
         parts = line.rstrip().split("=")
         if len(parts) == 2 and parts[0] == "broker.id":
@@ -6,7 +11,7 @@ def _parse_meta_properties_file(content):
     return None
 
 
-def _read_generated_broker_id(meta_properties_path):
+def _read_generated_broker_id(meta_properties_path: str) -> int:
     """reads broker_id from meta.properties file.
 
     :param string meta_properties_path: path for meta.properties file
@@ -28,7 +33,7 @@ def _read_generated_broker_id(meta_properties_path):
     return broker_id
 
 
-def get_broker_id(data_path):
+def get_broker_id(data_path: str) -> int:
     """This function will look into the data folder to get the automatically created
     broker_id.
 

--- a/kafka_utils/kafka_check/status_code.py
+++ b/kafka_utils/kafka_check/status_code.py
@@ -11,7 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 import sys
+from typing import Any
+
+from typing_extensions import TypedDict
 
 from kafka_utils.util import print_json
 
@@ -26,14 +31,19 @@ STATUS_STRING = {
 }
 
 
-def prepare_terminate_message(string):
+class TerminateMessageDict(TypedDict):
+    message: str
+    raw: str
+
+
+def prepare_terminate_message(string: str) -> TerminateMessageDict:
     return {
         'message': string,
         'raw': string,
     }
 
 
-def terminate(err_code, msg, json):
+def terminate(err_code: int, msg: dict[str, Any], json: bool) -> None:
     if json:
         output = {
             'status': STATUS_STRING[err_code],

--- a/kafka_utils/kafka_consumer_manager/commands/offset_set.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_set.py
@@ -11,8 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 import sys
 from collections import defaultdict
+from typing import DefaultDict
 
 from .offset_manager import OffsetWriter
 from kafka_utils.util.client import KafkaToolClient
@@ -20,7 +23,7 @@ from kafka_utils.util.offsets import set_consumer_offsets
 
 
 class OffsetSet(OffsetWriter):
-    new_offsets_dict = defaultdict(dict)
+    new_offsets_dict: DefaultDict[str, dict[int, int]] = defaultdict(dict)
 
     @classmethod
     def topics_dict(cls, string):

--- a/kafka_utils/kafka_consumer_manager/commands/offset_set_timestamp.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_set_timestamp.py
@@ -11,10 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 import sys
 from collections import defaultdict
 from collections import OrderedDict
 from datetime import datetime
+from typing import DefaultDict
 
 import pytz
 from kafka import KafkaConsumer
@@ -27,7 +30,7 @@ from kafka_utils.kafka_consumer_manager.util import topic_offsets_for_timestamp
 
 class OffsetSetTimestamp(OffsetManagerBase):
 
-    new_offsets_dict = defaultdict(dict)
+    new_offsets_dict: DefaultDict[str, dict[int, int]] = defaultdict(dict)
 
     @classmethod
     def topics_dict(cls, string):

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,14 @@
+[mypy]
+python_version = 3.7
+
+[mypy-humanfriendly.*]
+ignore_missing_imports = true
+
+[mypy-kafka.*]
+ignore_missing_imports = true
+
+[mypy-kazoo.*]
+ignore_missing_imports = true
+
+[mypy-requests_futures.*]
+ignore_missing_imports = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,7 @@ pre-commit==1.14.4
 pytest==3.9.3
 setuptools==40.0.0
 tox-pip-extensions==1.2.1
+types-paramiko
+types-pytz
+types-PyYAML
+types-requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ cryptography==3.0
 flake8
 importlib-metadata==3.7.2
 mock
+mypy
 pre-commit==1.14.4
 pytest==3.9.3
 setuptools==40.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,5 @@ pytz==2018.4
 pycparser==2.18
 requests==2.21.0
 requests-futures==0.9.9
-retrying==1.3.3
 setproctitle==1.1.10
 simplejson==3.16.0

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         "requests-futures>0.9.0",
         "paramiko>1.8.0,<3.0.0",
         "requests<3.0.0",
-        "retrying",
+        "tenacity",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         "paramiko>1.8.0,<3.0.0",
         "requests<3.0.0",
         "tenacity",
+        "typing-extensions>=3.7.4",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ commands =
     unittest: pre-commit run --all-files
     unittest: py.test -s {posargs}
     unittest: flake8 .
+    unittest: mypy kafka_utils/
 
     dockeritest: docker-compose rm --force
     dockeritest: docker-compose build


### PR DESCRIPTION
This annotates the `kafka_utils.kafka_check` module. It doesn't have any real effect right now, but this repo is large so annotating in chunks makes sense.

I also migrated from retrying to tenacity, since retrying is a dead package and tenacity has type annotations.