### PR TITLE
Prometheus support

### DIFF
--- a/kafka_utils/kafka_rolling_restart/main.py
+++ b/kafka_utils/kafka_rolling_restart/main.py
@@ -123,13 +123,13 @@ def parse_opts():
     )
     parser.add_argument(
         '--exporter-port',
-        help='the jolokia port on the server. Default: %(default)s',
+        help='the metrics exporter port on the server. Default: %(default)s',
         type=int,
         default=DEFAULT_EXPORTER_PORT,
     )
     parser.add_argument(
         '--exporter-suffix',
-        help='the jolokia HTTP prefix. Default: %(default)s',
+        help='the metrics exporter suffix. Default: %(default)s',
         type=str,
         default=DEFAULT_EXPORTER_SUFFIX,
     )
@@ -258,9 +258,8 @@ def filter_broker_list(brokers, filter_by):
     return [(id, host) for id, host in brokers if id in filter_by_set]
 
 def prometheus_requests(hosts, metrics_port, metrics_prefix):
-    """Use Prometheus to return a generator of requests to fetch the under replicated
-    partition number from the specified hosts.
-
+    """Use Prometheus to fetch the under replicated partition number from the specified hosts.
+    
     :param hosts: list of brokers ip addresses
     :type hosts: list of strings
     :param metrics_port: HTTP port for Prometheus
@@ -294,8 +293,7 @@ def prometheus_requests(hosts, metrics_port, metrics_prefix):
             yield host, PrometheusRes(s.status_code, int_value)
 
 def jolokia_requests(hosts, metrics_port, metrics_prefix, jolokia_user, jolokia_password):
-    """Use Jolokita to return a generator of requests to fetch the under replicated
-    partition number from the specified hosts.
+    """Use Jolokita to fetch the under replicated partition number from the specified hosts.
 
     :param hosts: list of brokers ip addresses
     :type hosts: list of strings
@@ -326,8 +324,8 @@ def jolokia_requests(hosts, metrics_port, metrics_prefix, jolokia_user, jolokia_
         yield host, JolokiaRes(s.status_code, s.json())
 
 def generate_requests(hosts, metrics_port, metrics_prefix, jolokia_user, jolokia_password, is_prometheus):
-    """Return a generator of requests to fetch the under replicated
-    partition number from the specified hosts.
+    """By default, use Jolokia to fetch under replicated metrics.
+    If is_prometheus bool set to true, use Prometheus exporter to fetch it.
 
     :param hosts: list of brokers ip addresses
     :type hosts: list of strings

--- a/kafka_utils/kafka_rolling_restart/main.py
+++ b/kafka_utils/kafka_rolling_restart/main.py
@@ -292,7 +292,7 @@ def prometheus_requests(hosts, metrics_port, metrics_prefix):
                 match = prometheus_requests_parse(s.text, EXPORTER_UNDER_REPL_KEY)
                 int_value = int(match.samples[0].value)
             except AssertionError:
-                print("Prometheus is not ready, or unable to find key: {}".format(EXPORTER_UNDER_REPL_KEY))
+                print("Unable to find key: {}".format(EXPORTER_UNDER_REPL_KEY))
                 yield host, PrometheusRes(400, Any, PrometheusNotReady)
             except Exception as e:
                 print("Prometheus is not ready.\n{e}".format(e))

--- a/kafka_utils/kafka_rolling_restart/main.py
+++ b/kafka_utils/kafka_rolling_restart/main.py
@@ -289,11 +289,10 @@ def prometheus_requests(hosts, metrics_port, metrics_prefix):
         else:
             try:
                 match = prometheus_requests_parse(s.text, EXPORTER_UNDER_REPL_KEY)
-                int_value = int(match.samples[0].value)
             except AssertionError:
                 print("Prometheus is not ready, or unable to find key: {}".format(EXPORTER_UNDER_REPL_KEY))
                 yield host, PrometheusRes(400, Any, PrometheusNotReady)
-            yield host, PrometheusRes(s.status_code, int_value)
+            yield host, PrometheusRes(s.status_code, int(match.samples[0].value))
 
 def jolokia_requests(hosts, metrics_port, metrics_prefix, jolokia_user, jolokia_password):
     """Use Jolokita to fetch the under replicated partition number from the specified hosts.

--- a/kafka_utils/kafka_rolling_restart/main.py
+++ b/kafka_utils/kafka_rolling_restart/main.py
@@ -289,13 +289,14 @@ def prometheus_requests(hosts, metrics_port, metrics_prefix):
         else:
             try:
                 match = prometheus_requests_parse(s.text, EXPORTER_UNDER_REPL_KEY)
+                int_value = int(match.samples[0].value)
             except AssertionError:
                 print("Prometheus is not ready, or unable to find key: {}".format(EXPORTER_UNDER_REPL_KEY))
                 yield host, PrometheusRes(400, Any, PrometheusNotReady)
             except Exception as e:
                 print("Prometheus is not ready.\n{e}".format(e))
                 yield host, PrometheusRes(400, Any, PrometheusNotReady)
-            yield host, PrometheusRes(s.status_code, int(match.samples[0].value))
+            yield host, PrometheusRes(s.status_code, int_value)
 
 def jolokia_requests(hosts, metrics_port, metrics_prefix, jolokia_user, jolokia_password):
     """Use Jolokita to fetch the under replicated partition number from the specified hosts.

--- a/kafka_utils/kafka_rolling_restart/main.py
+++ b/kafka_utils/kafka_rolling_restart/main.py
@@ -285,7 +285,7 @@ def prometheus_requests(hosts, metrics_port, metrics_prefix):
             try:
                 match = re.search(pattern, s.text)
                 if match is None:
-                    return host, PrometheusRes(400, Any, PrometheusNotReady)
+                    yield host, PrometheusRes(400, Any, PrometheusNotReady)
                 int_value = int(float(match.group(3)))
             except re.error:
                 print("Regex pattern match failed for: {}".format(pattern))

--- a/kafka_utils/kafka_rolling_restart/main.py
+++ b/kafka_utils/kafka_rolling_restart/main.py
@@ -289,12 +289,10 @@ def prometheus_requests(hosts, metrics_port, metrics_prefix):
         else:
             try:
                 match = prometheus_requests_parse(s.text, EXPORTER_UNDER_REPL_KEY)
-                if match is None:
-                    yield host, PrometheusRes(400, Any, PrometheusNotReady)
                 int_value = int(match.samples[0].value)
             except AssertionError:
-                print("Unable to find key in Prometheus output: {}".format(EXPORTER_UNDER_REPL_KEY))
-                yield host, PrometheusRes(400, Any)
+                print("Prometheus is not ready, or unable to find key: {}".format(EXPORTER_UNDER_REPL_KEY))
+                yield host, PrometheusRes(400, Any, PrometheusNotReady)
             yield host, PrometheusRes(s.status_code, int_value)
 
 def jolokia_requests(hosts, metrics_port, metrics_prefix, jolokia_user, jolokia_password):

--- a/kafka_utils/kafka_rolling_restart/main.py
+++ b/kafka_utils/kafka_rolling_restart/main.py
@@ -292,6 +292,9 @@ def prometheus_requests(hosts, metrics_port, metrics_prefix):
             except AssertionError:
                 print("Prometheus is not ready, or unable to find key: {}".format(EXPORTER_UNDER_REPL_KEY))
                 yield host, PrometheusRes(400, Any, PrometheusNotReady)
+            except Exception as e:
+                print("Prometheus is not ready.\n{e}".format(e))
+                yield host, PrometheusRes(400, Any, PrometheusNotReady)
             yield host, PrometheusRes(s.status_code, int(match.samples[0].value))
 
 def jolokia_requests(hosts, metrics_port, metrics_prefix, jolokia_user, jolokia_password):

--- a/kafka_utils/kafka_rolling_restart/main.py
+++ b/kafka_utils/kafka_rolling_restart/main.py
@@ -287,6 +287,7 @@ def prometheus_requests(hosts, metrics_port, metrics_prefix):
         if s.status_code != 200:
             yield host, PrometheusRes(400,Any, exception_type)
         else:
+            int_value = 0
             try:
                 match = prometheus_requests_parse(s.text, EXPORTER_UNDER_REPL_KEY)
                 int_value = int(match.samples[0].value)

--- a/kafka_utils/kafka_rolling_restart/response.py
+++ b/kafka_utils/kafka_rolling_restart/response.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class PrometheusRes:
+  """ API for metrics source. Return Prometheus Response.
+      :returns Prometheus Response - status_code, json, exception
+      :rtype: status_code: int , json: str, exception: Exception
+  """
+  def __init__(self, status_code, json, exception=None):
+    self.status_code = status_code
+    self.json = json
+    self.exception = exception
+
+class JolokiaRes:
+  """ API for metrics source. Return Jolokia Response.
+      :returns Jolokia Response - status_code, json, exception
+      :rtype: status_code: int , json: str, exception: Exception
+  """
+  def __init__(self, status_code, json, exception=None):
+    self.status_code = status_code
+    self.json = json
+    self.exception = exception

--- a/kafka_utils/kafka_rolling_restart/response.py
+++ b/kafka_utils/kafka_rolling_restart/response.py
@@ -13,7 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-class PrometheusRes:
+from abc import ABCMeta, abstractmethod
+
+class BaseRes():
+    __metaclass__ = ABCMeta
+    @abstractmethod
+    def __init__(self, status_code, json, exception=None):
+      self.status_code = status_code
+      self.json = json
+      self.exception = exception
+
+class PrometheusRes(BaseRes):
   """ API for metrics source. Return Prometheus Response.
       :returns Prometheus Response - status_code, json, exception
       :rtype: status_code: int , json: str, exception: Exception
@@ -22,8 +32,9 @@ class PrometheusRes:
     self.status_code = status_code
     self.json = json
     self.exception = exception
+    
 
-class JolokiaRes:
+class JolokiaRes(BaseRes):
   """ API for metrics source. Return Jolokia Response.
       :returns Jolokia Response - status_code, json, exception
       :rtype: status_code: int , json: str, exception: Exception

--- a/kafka_utils/util/ssh.py
+++ b/kafka_utils/util/ssh.py
@@ -92,7 +92,7 @@ class Connection:
 
 
 @contextmanager
-def ssh(host, forward_agent=False, sudoable=False, max_attempts=1, max_timeout=5, ssh_password=None):
+def ssh(host, forward_agent=False, sudoable=False, max_attempts=1, max_timeout=5, ssh_password=None, ssh_username=None):
     """Manages a SSH connection to the desired host.
        Will leverage your ssh config at ~/.ssh/config if available
 
@@ -108,6 +108,8 @@ def ssh(host, forward_agent=False, sudoable=False, max_attempts=1, max_timeout=5
     :type max_timeout: int
     :param ssh_password: SSH password to use if needed
     :type ssh_password: str
+    :param ssh_username: SSH username to use if needed
+    :type ssh_username: str
     :returns a SSH connection to the desired host
     :rtype: Connection
 
@@ -123,6 +125,8 @@ def ssh(host, forward_agent=False, sudoable=False, max_attempts=1, max_timeout=5
         }
         if ssh_password:
             cfg['password'] = ssh_password
+        if ssh_username:
+            cfg['username'] = ssh_username
 
         ssh_config = SSHConfig()
         user_config_file = os.path.expanduser("~/.ssh/config")

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ retrying==1.3.3
 setproctitle==1.1.10
 simplejson==3.16.0
 six==1.12.0
-prometheus-client=0.14.1
+prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ retrying==1.3.3
 setproctitle==1.1.10
 simplejson==3.16.0
 six==1.12.0
+prometheus-client=0.14.1

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         "requests<3.0.0",
         "retrying",
         "six>=1.10.0",
+        "prometheus-client=0.14.1",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         "requests<3.0.0",
         "retrying",
         "six>=1.10.0",
-        "prometheus-client=0.14.1",
+        "prometheus-client>=0.14.1",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/tests/kafka_rolling_restart/test_main.py
+++ b/tests/kafka_rolling_restart/test_main.py
@@ -32,7 +32,7 @@ def test_read_cluster_value_partitions(mock_get):
     request = mock_get.return_value
     request.result.return_value = response
 
-    p, b = main.read_cluster_status(["host1", "host2", "host3"], 80, "jolokia", None, None)
+    p, b = main.read_cluster_status(["host1", "host2", "host3"], 80, "jolokia", None, None, False)
 
     assert p == 3   # 3 missing partitions
     assert b == 0   # 0 missing brokers
@@ -46,7 +46,7 @@ def test_read_cluster_value_exit(mock_get):
     request.result.return_value = response
 
     with pytest.raises(SystemExit):
-        p, b = main.read_cluster_status(["host1"], 80, "jolokia", None, None)
+        p, b = main.read_cluster_status(["host1"], 80, "jolokia", None, None, False)
 
 
 @mock.patch.object(main.FuturesSession, 'get', autospec=True)
@@ -57,7 +57,7 @@ def test_read_cluster_value_no_key(mock_get):
     request = mock_get.return_value
     request.result.return_value = response
 
-    p, b = main.read_cluster_status(["host1"], 80, "jolokia", None, None)
+    p, b = main.read_cluster_status(["host1"], 80, "jolokia", None, None, False)
 
     assert p == 0   # 0 missing partitions
     assert b == 1   # 1 missing brokers
@@ -68,7 +68,7 @@ def test_read_cluster_value_server_down(mock_get):
     request = mock_get.return_value
     request.result.side_effect = RequestException
 
-    p, b = main.read_cluster_status(["host1"], 80, "jolokia", None, None)
+    p, b = main.read_cluster_status(["host1"], 80, "jolokia", None, None, False)
 
     assert p == 0   # 0 missing partitions
     assert b == 1   # 1 missing brokers
@@ -89,7 +89,7 @@ def read_cluster_state_values(first_part, repeat):
 )
 @mock.patch('time.sleep', autospec=True)
 def test_wait_for_stable_cluster_success(mock_sleep, mock_read):
-    main.wait_for_stable_cluster([], 1, "", None, None, 5, 3, 100)
+    main.wait_for_stable_cluster([], 1, "", None, None, 5, 3, 100, False)
 
     assert mock_read.call_count == 6
     assert mock_sleep.mock_calls == [mock.call(5)] * 5
@@ -104,7 +104,7 @@ def test_wait_for_stable_cluster_success(mock_sleep, mock_read):
 @mock.patch('time.sleep', autospec=True)
 def test_wait_for_stable_cluster_timeout(mock_sleep, mock_read):
     with pytest.raises(main.WaitTimeoutException):
-        main.wait_for_stable_cluster([], 1, "", None, None, 5, 3, 100)
+        main.wait_for_stable_cluster([], 1, "", None, None, 5, 3, 100, False)
 
     assert mock_read.call_count == 21
     assert mock_sleep.mock_calls == [mock.call(5)] * 20


### PR DESCRIPTION
Hi,
I've made some changes to the metric reporter to be generic using abstract methods.
In this PR I've added Prometheus support, but the idea is to let users extend it to whatever metric reporters they are using as long as they implement the BaseRes abstract method:
https://github.com/EladLeev/kafka-utils/blob/prometheus_support/kafka_utils/kafka_rolling_restart/response.py

Using it in Production for few months now, but I didn't had a chance to finish it up with tests, proper documentation, and to resolve conflicts from main branch 🥲  -- if anyone want to assist, more than welcome!

Thank you for the awesome project 
