### PR TITLE
add type annotations to kafka_utils.kafka_cluster_manager.cluster_info.broker

### DIFF
--- a/kafka_utils/kafka_cluster_manager/cluster_info/partition.py
+++ b/kafka_utils/kafka_cluster_manager/cluster_info/partition.py
@@ -11,7 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from .broker import Broker
 from .error import InvalidPartitionMeasurementError
+from .topic import Topic
 
 
 class Partition:
@@ -20,7 +24,7 @@ class Partition:
     (list of brokers).
     """
 
-    def __init__(self, topic, id, replicas=None, weight=0, size=0):
+    def __init__(self, topic: Topic, id: int, replicas: list[Broker] | None = None, weight: float = 0, size: float = 0) -> None:
         # Every partition name has (topic, partition) tuple
         self._name = (topic.id, id)
         self._replicas = replicas or []
@@ -45,42 +49,42 @@ class Partition:
         self._size = size
 
     @property
-    def name(self):
+    def name(self) -> tuple[str, int]:
         "Name of partition, consisting of (topic_id, partition_id) tuple."""
         return self._name
 
     @property
-    def partition_id(self):
+    def partition_id(self) -> int:
         """Partition id component of the partition-tuple."""
         return int(self._name[1])
 
     @property
-    def topic(self):
+    def topic(self) -> Topic:
         return self._topic
 
     @property
-    def replicas(self):
+    def replicas(self) -> list[Broker]:
         """List of brokers in partition."""
         return self._replicas
 
     @property
-    def leader(self):
+    def leader(self) -> Broker:
         """Leader broker for the partition."""
         return self._replicas[0]
 
     @property
-    def replication_factor(self):
+    def replication_factor(self) -> int:
         return len(self._replicas)
 
     @property
-    def followers(self):
+    def followers(self) -> list[Broker]:
         """Return list of brokers not as preferred leader
         for a particular partition.
         """
         return self._replicas[1:]
 
     @property
-    def weight(self):
+    def weight(self) -> float:
         """Return a number representing the relative weight of this partition
         compared to the other partitions in the cluster. The weight is a
         measure of how much load this partition will place on any broker that
@@ -89,18 +93,18 @@ class Partition:
         return self._weight
 
     @property
-    def size(self):
+    def size(self) -> float:
         """Return a number representing the size of this partition. The size is
         a measure of how expensive it is to move this partition from one broker
         to another.
         """
         return self._size
 
-    def add_replica(self, broker):
+    def add_replica(self, broker: Broker) -> None:
         """Add broker to existing set of replicas."""
         self._replicas.append(broker)
 
-    def swap_leader(self, new_leader):
+    def swap_leader(self, new_leader: Broker) -> Broker:
         """Change the preferred leader with one of
         given replicas.
 
@@ -115,7 +119,7 @@ class Partition:
             self._replicas[idx], self._replicas[0]
         return curr_leader
 
-    def replace(self, source, dest):
+    def replace(self, source: Broker, dest: Broker) -> None:
         """Replace source broker with destination broker in replica set if found."""
         if dest is None:
             # Remove source if it's there
@@ -126,7 +130,7 @@ class Partition:
                 self.replicas[i] = dest
                 return
 
-    def count_siblings(self, partitions):
+    def count_siblings(self, partitions: list[Partition]) -> int:
         """Count siblings of partition in given partition-list.
 
         :key-term:
@@ -138,8 +142,8 @@ class Partition:
         )
         return count
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self._name}"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self}"

--- a/kafka_utils/kafka_cluster_manager/cluster_info/partition_measurer.py
+++ b/kafka_utils/kafka_cluster_manager/cluster_info/partition_measurer.py
@@ -11,8 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+import argparse
 import itertools
 import shlex
+
+from kafka_utils.kafka_cluster_manager.cluster_info.broker import Broker
+from kafka_utils.util.config import ClusterConfig
 
 
 class PartitionMeasurer:
@@ -25,11 +31,11 @@ class PartitionMeasurer:
     """
 
     def __init__(
-            self,
-            cluster_config,
-            brokers,
-            assignment,
-            args,
+        self,
+        cluster_config: ClusterConfig,
+        brokers: list[Broker],
+        assignment: dict[tuple[str, int], list[int]],
+        args: argparse.Namespace,
     ):
         self.cluster_config = cluster_config
         self.brokers = brokers
@@ -42,14 +48,14 @@ class PartitionMeasurer:
         else:
             self.parse_args([])
 
-    def parse_args(self, _measurer_args):
+    def parse_args(self, _measurer_args: list[str]) -> None:
         """Parse partition measurer command line arguments.
 
         :param _measurer_args: The list of arguments as strings.
         """
         pass
 
-    def get_weight(self, partition_name):
+    def get_weight(self, partition_name: tuple[str, int]) -> float:
         """Return a positive number representing the relative weight of this
         partition compared to the other partitions in the cluster. The weight
         is a measure of how much load this partition will place on any broker
@@ -59,7 +65,7 @@ class PartitionMeasurer:
         """
         raise NotImplementedError("Implement in subclass.")
 
-    def get_size(self, partition_name):
+    def get_size(self, partition_name: tuple[str, int]) -> float:
         """Return a positive number representing the size of this partition.
         The size is a measure of how expensive it is to move this partition
         from one broker to another.
@@ -74,8 +80,8 @@ class UniformPartitionMeasurer(PartitionMeasurer):
     for all partitions.
     """
 
-    def get_weight(self, _):
+    def get_weight(self, partition_name: tuple[str, int]) -> float:
         return 1.0
 
-    def get_size(self, _):
+    def get_size(self, partition_name: tuple[str, int]) -> float:
         return 1.0

--- a/kafka_utils/kafka_cluster_manager/cluster_info/replication_group_parser.py
+++ b/kafka_utils/kafka_cluster_manager/cluster_info/replication_group_parser.py
@@ -11,12 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from kafka_utils.kafka_cluster_manager.cluster_info.broker import Broker
 
 
 class ReplicationGroupParser:
     """Base class for replication group parsers"""
 
-    def get_replication_group(self, broker):
+    def get_replication_group(self, broker: Broker) -> str | None:
         """Implement the logic to extract the replication group id of a broker.
 
         This method is called with a broker object as argument.
@@ -38,7 +41,7 @@ class ReplicationGroupParser:
 
 class DefaultReplicationGroupParser(ReplicationGroupParser):
 
-    def get_replication_group(self, broker):
+    def get_replication_group(self, broker: Broker) -> str | None:
         """Default group is None. All brokers are considered in the same group.
 
         TODO: Support kafka 0.10 and rack tag.

--- a/kafka_utils/kafka_cluster_manager/cluster_info/topic.py
+++ b/kafka_utils/kafka_cluster_manager/cluster_info/topic.py
@@ -16,7 +16,13 @@
 Useful as part of reassignment project when deciding upon moving
 partitions of same topic over different brokers.
 """
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kafka_utils.kafka_cluster_manager.cluster_info.partition import Partition
 
 
 class Topic:
@@ -28,36 +34,36 @@ class Topic:
         partitions:         List of Partition objects
     """
 
-    def __init__(self, id, replication_factor=0, partitions=None):
+    def __init__(self, id: str, replication_factor: int = 0, partitions: set[Partition] | None = None) -> None:
         self._id = id
         self._replication_factor = replication_factor
         self._partitions = partitions or set()
         self.log = logging.getLogger(self.__class__.__name__)
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._id
 
     @property
-    def replication_factor(self):
+    def replication_factor(self) -> int:
         return self._replication_factor
 
     @property
-    def partitions(self):
+    def partitions(self) -> set[Partition]:
         return self._partitions
 
     @property
-    def weight(self):
+    def weight(self) -> float:
         return sum(
             partition.weight * partition.replication_factor
             for partition in self._partitions
         )
 
-    def add_partition(self, partition):
+    def add_partition(self, partition: Partition) -> None:
         self._partitions.add(partition)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self._id}"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self}"

--- a/kafka_utils/kafka_cluster_manager/cluster_info/util.py
+++ b/kafka_utils/kafka_cluster_manager/cluster_info/util.py
@@ -11,9 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from collections.abc import Collection
+from typing import Any
+from typing import Callable
+from typing import TypeVar
 
 
-def compute_optimum(groups, elements):
+def compute_optimum(groups: int, elements: int) -> tuple[int, int]:
     """Compute the number of elements per group and the remainder.
 
         :param elements: total number of elements
@@ -22,7 +28,10 @@ def compute_optimum(groups, elements):
     return elements // groups, elements % groups
 
 
-def _smart_separate_groups(groups, key, total):
+T = TypeVar('T')
+
+
+def _smart_separate_groups(groups: Collection[T], key: Callable[[T], Any], total: int) -> tuple[list[T], list[T], list[T]]:
     """Given a list of group objects, and a function to extract the number of
     elements for each of them, return the list of groups that have an excessive
     number of elements (when compared to a uniform distribution), a list of
@@ -52,7 +61,7 @@ def _smart_separate_groups(groups, key, total):
     return over_loaded, under_loaded, optimal
 
 
-def separate_groups(groups, key, total):
+def separate_groups(groups: Collection[T], key: Callable[[T], Any], total: int) -> tuple[list[T], list[T]]:
     """Separate the group into overloaded and under-loaded groups.
 
     The revised over-loaded groups increases the choice space for future

--- a/tests/kafka_cluster_manager/cmds/command_test.py
+++ b/tests/kafka_cluster_manager/cmds/command_test.py
@@ -70,7 +70,7 @@ def cluster_topology(new_assignment):
     """
     brokers = {0: None, 1: None, 2: None, 3: None}
     pm = UniformPartitionMeasurer({}, brokers, new_assignment, {})
-    return ClusterTopology(new_assignment, brokers, pm)
+    return ClusterTopology(new_assignment, brokers, pm, lambda _: 'id')
 
 
 @fixture
@@ -79,7 +79,7 @@ def empty_cluster_topology():
     """
     brokers = {0: None, 1: None, 2: None, 3: None}
     pm = UniformPartitionMeasurer({}, brokers, {}, {})
-    return ClusterTopology({}, brokers, pm)
+    return ClusterTopology({}, brokers, pm, lambda _: 'id')
 
 
 @fixture
@@ -88,7 +88,7 @@ def orig_cluster_topology(orig_assignment):
     """
     brokers = {0: None, 1: None, 2: None, 3: None}
     pm = UniformPartitionMeasurer({}, brokers, orig_assignment, {})
-    return ClusterTopology(orig_assignment, brokers, pm)
+    return ClusterTopology(orig_assignment, brokers, pm, lambda _: 'id')
 
 
 class MixedSizePartitionMeasurer(PartitionMeasurer):
@@ -109,7 +109,7 @@ class MixedSizePartitionMeasurer(PartitionMeasurer):
 def two_partition_same_topic_topology(two_partition_same_topic_assignment):
     brokers = {0: None, 1: None, 2: None, 3: None}
     pm = MixedSizePartitionMeasurer({}, brokers, two_partition_same_topic_assignment, {})
-    return ClusterTopology(two_partition_same_topic_assignment, brokers, pm)
+    return ClusterTopology(two_partition_same_topic_assignment, brokers, pm, lambda _: 'id')
 
 
 class ZeroSizePartitionMeasurer(PartitionMeasurer):
@@ -130,7 +130,7 @@ def zero_size_cluster_topology(orig_assignment):
     """
     brokers = {0: None, 1: None, 2: None, 3: None}
     pm = ZeroSizePartitionMeasurer({}, brokers, orig_assignment, {})
-    return ClusterTopology(orig_assignment, brokers, pm)
+    return ClusterTopology(orig_assignment, brokers, pm, lambda _: 'id')
 
 
 @fixture


### PR DESCRIPTION
A few notable things here:
- ClusterTopology now requires the `extract_group` argument. This is because it was effectively required by the fact that it's called without checking for `None`. And all non-test usages set it.
- GeneticBalancer.rebalance had a logic error where it tries to iterate over a dict. This works but just iterates over the keys of the dict, not the items. I fixed this by calling `.items()` on the dict and iterating over that. This implies that this code is dead though, since it almost certainly crashed and definitely didn't work.