### PR TITLE
Add type annotations part 3

### DIFF
--- a/kafka_utils/kafka_check/commands/command.py
+++ b/kafka_utils/kafka_check/commands/command.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 from typing import Any
 from typing import cast
+from typing import Dict
 
 from kafka_utils.kafka_check import status_code
 from kafka_utils.kafka_check.status_code import prepare_terminate_message
@@ -58,7 +59,7 @@ class KafkaCheckCmd:
             if args.controller_only and not is_controller(self.zk, args.broker_id):
                 terminate(
                     status_code.OK,
-                    cast(dict[str, Any], prepare_terminate_message(
+                    cast(Dict[str, Any], prepare_terminate_message(
                         'Broker {} is not the controller, nothing to check'
                         .format(args.broker_id),
                     )),
@@ -67,7 +68,7 @@ class KafkaCheckCmd:
             if args.first_broker_only and not broker_ids:
                 terminate(
                     status_code.OK,
-                    cast(dict[str, Any], prepare_terminate_message(
+                    cast(Dict[str, Any], prepare_terminate_message(
                         'No brokers detected, nothing to check'
                     )),
                     args.json,
@@ -75,7 +76,7 @@ class KafkaCheckCmd:
             if args.first_broker_only and not is_first_broker(broker_ids, args.broker_id):
                 terminate(
                     status_code.OK,
-                    cast(dict[str, Any], prepare_terminate_message(
+                    cast(Dict[str, Any], prepare_terminate_message(
                         'Broker {} has not the lowest id, nothing to check'
                         .format(args.broker_id),
                     )),

--- a/kafka_utils/kafka_check/commands/offline.py
+++ b/kafka_utils/kafka_check/commands/offline.py
@@ -15,7 +15,9 @@ from __future__ import annotations
 
 import itertools
 import sys
+from collections.abc import Collection
 from typing import Any
+from typing import cast
 
 from kafka_utils.kafka_check import status_code
 from kafka_utils.kafka_check.commands.command import KafkaCheckCmd
@@ -37,17 +39,17 @@ class OfflineCmd(KafkaCheckCmd):
 
     def run_command(self) -> tuple[int, dict[str, Any]]:
         """Checks the number of offline partitions"""
-        offline = get_topic_partition_with_error(
+        offline = cast(set[tuple[str, int]], get_topic_partition_with_error(
             self.cluster_config,
             LEADER_NOT_AVAILABLE_ERROR,
-        )
+        ))
 
         errcode = status_code.OK if not offline else status_code.CRITICAL
         out = _prepare_output(offline, self.args.verbose, self.args.head)
         return errcode, out
 
 
-def _prepare_output(partitions: list[tuple[str, int]], verbose: bool, head_limit: int) -> dict[str, Any]:
+def _prepare_output(partitions: Collection[tuple[str, int]], verbose: bool, head_limit: int) -> dict[str, Any]:
     """Returns dict with 'raw' and 'message' keys filled."""
     out: dict[str, Any] = {}
     partitions_count = len(partitions)

--- a/kafka_utils/kafka_check/commands/offline.py
+++ b/kafka_utils/kafka_check/commands/offline.py
@@ -18,6 +18,8 @@ import sys
 from collections.abc import Collection
 from typing import Any
 from typing import cast
+from typing import Set
+from typing import Tuple
 
 from kafka_utils.kafka_check import status_code
 from kafka_utils.kafka_check.commands.command import KafkaCheckCmd
@@ -39,7 +41,7 @@ class OfflineCmd(KafkaCheckCmd):
 
     def run_command(self) -> tuple[int, dict[str, Any]]:
         """Checks the number of offline partitions"""
-        offline = cast(set[tuple[str, int]], get_topic_partition_with_error(
+        offline = cast(Set[Tuple[str, int]], get_topic_partition_with_error(
             self.cluster_config,
             LEADER_NOT_AVAILABLE_ERROR,
         ))

--- a/kafka_utils/kafka_check/commands/replica_unavailability.py
+++ b/kafka_utils/kafka_check/commands/replica_unavailability.py
@@ -14,7 +14,9 @@
 from __future__ import annotations
 
 import itertools
+from collections.abc import Collection
 from typing import Any
+from typing import cast
 
 from kafka_utils.kafka_check import status_code
 from kafka_utils.kafka_check.commands.command import KafkaCheckCmd
@@ -36,23 +38,19 @@ class ReplicaUnavailabilityCmd(KafkaCheckCmd):
     def run_command(self) -> tuple[int, dict[str, Any]]:
         """replica_unavailability command, checks number of replicas not available
         for communication over all brokers in the Kafka cluster."""
-        fetch_unavailable_brokers = True
-        result = get_topic_partition_with_error(
+        result = cast(tuple[set[tuple[str, int]], set[int]], get_topic_partition_with_error(
             self.cluster_config,
             REPLICA_NOT_AVAILABLE_ERROR,
-            fetch_unavailable_brokers=fetch_unavailable_brokers,
-        )
-        if fetch_unavailable_brokers:
-            replica_unavailability, unavailable_brokers = result
-        else:
-            replica_unavailability = result
+            fetch_unavailable_brokers=True,
+        ))
+        replica_unavailability, unavailable_brokers = result
 
         errcode = status_code.OK if not replica_unavailability else status_code.CRITICAL
         out = _prepare_output(replica_unavailability, unavailable_brokers, self.args.verbose, self.args.head)
         return errcode, out
 
 
-def _prepare_output(partitions: list[tuple[str, int]], unavailable_brokers: list[int], verbose: bool, head_limit: int) -> dict[str, Any]:
+def _prepare_output(partitions: Collection[tuple[str, int]], unavailable_brokers: set[int], verbose: bool, head_limit: int) -> dict[str, Any]:
     """Returns dict with 'raw' and 'message' keys filled."""
     partitions_count = len(partitions)
     out: dict[str, Any] = {}

--- a/kafka_utils/kafka_check/commands/replica_unavailability.py
+++ b/kafka_utils/kafka_check/commands/replica_unavailability.py
@@ -17,6 +17,8 @@ import itertools
 from collections.abc import Collection
 from typing import Any
 from typing import cast
+from typing import Set
+from typing import Tuple
 
 from kafka_utils.kafka_check import status_code
 from kafka_utils.kafka_check.commands.command import KafkaCheckCmd
@@ -38,7 +40,7 @@ class ReplicaUnavailabilityCmd(KafkaCheckCmd):
     def run_command(self) -> tuple[int, dict[str, Any]]:
         """replica_unavailability command, checks number of replicas not available
         for communication over all brokers in the Kafka cluster."""
-        result = cast(tuple[set[tuple[str, int]], set[int]], get_topic_partition_with_error(
+        result = cast(Tuple[Set[Tuple[str, int]], Set[int]], get_topic_partition_with_error(
             self.cluster_config,
             REPLICA_NOT_AVAILABLE_ERROR,
             fetch_unavailable_brokers=True,

--- a/kafka_utils/kafka_check/commands/replication_factor.py
+++ b/kafka_utils/kafka_check/commands/replication_factor.py
@@ -67,7 +67,7 @@ class TopicDict(TypedDict):
     topic: str
 
 
-def _find_topics_with_wrong_rp(topics: dict[str, list[PartitionMetadata]], zk: ZK, default_min_isr: int) -> list[TopicDict]:
+def _find_topics_with_wrong_rp(topics: dict[str, dict[int, PartitionMetadata]], zk: ZK, default_min_isr: int) -> list[TopicDict]:
     """Returns topics with wrong replication factor."""
     topics_with_wrong_rf: list[TopicDict] = []
 

--- a/kafka_utils/kafka_check/main.py
+++ b/kafka_utils/kafka_check/main.py
@@ -21,6 +21,7 @@ import argparse
 import logging
 from typing import Any
 from typing import cast
+from typing import Dict
 
 from kafka_utils.kafka_check import status_code
 from kafka_utils.kafka_check.commands.min_isr import MinIsrCmd
@@ -130,7 +131,7 @@ def validate_args(args: argparse.Namespace) -> None:
     if args.controller_only and args.first_broker_only:
         terminate(
             status_code.WARNING,
-            cast(dict[str, Any], prepare_terminate_message(
+            cast(Dict[str, Any], prepare_terminate_message(
                 "Only one of controller_only and first_broker_only should be used",
             )),
             args.json,
@@ -140,7 +141,7 @@ def validate_args(args: argparse.Namespace) -> None:
         if args.broker_id is None:
             terminate(
                 status_code.WARNING,
-                cast(dict[str, Any], prepare_terminate_message("broker_id is not specified")),
+                cast(Dict[str, Any], prepare_terminate_message("broker_id is not specified")),
                 args.json,
             )
         elif args.broker_id == -1:
@@ -149,14 +150,14 @@ def validate_args(args: argparse.Namespace) -> None:
             except Exception as e:
                 terminate(
                     status_code.WARNING,
-                    cast(dict[str, Any], prepare_terminate_message(f"{e}")),
+                    cast(Dict[str, Any], prepare_terminate_message(f"{e}")),
                     args.json,
                 )
 
     if args.head != -1 and not args.verbose:
         terminate(
             status_code.WARNING,
-            cast(dict[str, Any], prepare_terminate_message("--head option works only as addition to --verbose option")),
+            cast(Dict[str, Any], prepare_terminate_message("--head option works only as addition to --verbose option")),
             args.json,
         )
 
@@ -180,7 +181,7 @@ def run() -> None:
     except ConfigurationError as e:
         terminate(
             status_code.CRITICAL,
-            cast(dict[str, Any], prepare_terminate_message(f"ConfigurationError {e}")),
+            cast(Dict[str, Any], prepare_terminate_message(f"ConfigurationError {e}")),
             args.json,
         )
 

--- a/kafka_utils/kafka_consumer_manager/commands/copy_group.py
+++ b/kafka_utils/kafka_consumer_manager/commands/copy_group.py
@@ -11,10 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+import argparse
 import sys
+from typing import Any
 
 from .offset_manager import OffsetManagerBase
 from kafka_utils.util.client import KafkaToolClient
+from kafka_utils.util.config import ClusterConfig
 from kafka_utils.util.offsets import get_current_consumer_offsets
 from kafka_utils.util.offsets import set_consumer_offsets
 
@@ -22,7 +27,7 @@ from kafka_utils.util.offsets import set_consumer_offsets
 class CopyGroup(OffsetManagerBase):
 
     @classmethod
-    def setup_subparser(cls, subparsers):
+    def setup_subparser(cls, subparsers: Any) -> None:
         parser_copy_group = subparsers.add_parser(
             "copy_group",
             description="Copy specified consumer group details to a new group.",
@@ -51,7 +56,7 @@ class CopyGroup(OffsetManagerBase):
         parser_copy_group.set_defaults(command=cls.run)
 
     @classmethod
-    def run(cls, args, cluster_config):
+    def run(cls, args: argparse.Namespace, cluster_config: ClusterConfig) -> None:
         if args.source_groupid == args.dest_groupid:
             print(
                 "Error: Source group ID and destination group ID are same.",
@@ -78,6 +83,6 @@ class CopyGroup(OffsetManagerBase):
         )
 
     @classmethod
-    def copy_group_kafka(cls, client, topics, source_group, destination_group):
+    def copy_group_kafka(cls, client: KafkaToolClient, topics: dict[str, list[int]], source_group: int, destination_group: int) -> None:
         copied_offsets = get_current_consumer_offsets(client, source_group, topics)
         set_consumer_offsets(client, destination_group, copied_offsets)

--- a/kafka_utils/kafka_consumer_manager/commands/copy_group.py
+++ b/kafka_utils/kafka_consumer_manager/commands/copy_group.py
@@ -83,6 +83,6 @@ class CopyGroup(OffsetManagerBase):
         )
 
     @classmethod
-    def copy_group_kafka(cls, client: KafkaToolClient, topics: dict[str, list[int]], source_group: int, destination_group: int) -> None:
+    def copy_group_kafka(cls, client: KafkaToolClient, topics: dict[str, list[int]], source_group: str, destination_group: str) -> None:
         copied_offsets = get_current_consumer_offsets(client, source_group, topics)
         set_consumer_offsets(client, destination_group, copied_offsets)

--- a/kafka_utils/kafka_consumer_manager/commands/delete_group.py
+++ b/kafka_utils/kafka_consumer_manager/commands/delete_group.py
@@ -60,6 +60,6 @@ class DeleteGroup(OffsetWriter):
         cls.delete_group_kafka(client, args.groupid, topics_dict)
 
     @classmethod
-    def delete_group_kafka(cls, client: KafkaToolClient, group: int, topics: dict[str, dict[int, int]]) -> None:
+    def delete_group_kafka(cls, client: KafkaToolClient, group: str, topics: dict[str, dict[int, int]]) -> None:
         new_offsets = nullify_offsets(topics)
         set_consumer_offsets(client, group, new_offsets)

--- a/kafka_utils/kafka_consumer_manager/commands/delete_group.py
+++ b/kafka_utils/kafka_consumer_manager/commands/delete_group.py
@@ -11,8 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
 from .offset_manager import OffsetWriter
 from kafka_utils.util.client import KafkaToolClient
+from kafka_utils.util.config import ClusterConfig
 from kafka_utils.util.offsets import nullify_offsets
 from kafka_utils.util.offsets import set_consumer_offsets
 
@@ -20,7 +26,7 @@ from kafka_utils.util.offsets import set_consumer_offsets
 class DeleteGroup(OffsetWriter):
 
     @classmethod
-    def setup_subparser(cls, subparsers):
+    def setup_subparser(cls, subparsers: Any):
         parser_delete_group = subparsers.add_parser(
             "delete_group",
             description="Delete a consumer group by groupid. This "
@@ -38,7 +44,7 @@ class DeleteGroup(OffsetWriter):
         parser_delete_group.set_defaults(command=cls.run)
 
     @classmethod
-    def run(cls, args, cluster_config):
+    def run(cls, args: argparse.Namespace, cluster_config: ClusterConfig) -> None:
         # Setup the Kafka client
         client = KafkaToolClient(cluster_config.broker_list)
         client.load_metadata_for_topics()
@@ -54,6 +60,6 @@ class DeleteGroup(OffsetWriter):
         cls.delete_group_kafka(client, args.groupid, topics_dict)
 
     @classmethod
-    def delete_group_kafka(cls, client, group, topics):
+    def delete_group_kafka(cls, client: KafkaToolClient, group: int, topics: dict[str, dict[int, int]]) -> None:
         new_offsets = nullify_offsets(topics)
         set_consumer_offsets(client, group, new_offsets)

--- a/kafka_utils/kafka_consumer_manager/commands/list_groups.py
+++ b/kafka_utils/kafka_consumer_manager/commands/list_groups.py
@@ -11,14 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+import argparse
+from collections.abc import Collection
+from typing import Any
+
 from .offset_manager import OffsetManagerBase
 from kafka_utils.kafka_consumer_manager.util import get_kafka_group_reader
+from kafka_utils.util.config import ClusterConfig
 
 
 class ListGroups(OffsetManagerBase):
 
     @classmethod
-    def setup_subparser(cls, subparsers):
+    def setup_subparser(cls, subparsers: Any) -> None:
         parser_list_groups = subparsers.add_parser(
             "list_groups",
             description="List consumer groups.",
@@ -27,14 +34,14 @@ class ListGroups(OffsetManagerBase):
         parser_list_groups.set_defaults(command=cls.run)
 
     @classmethod
-    def get_kafka_groups(cls, cluster_config, use_admin_client=False):
+    def get_kafka_groups(cls, cluster_config: ClusterConfig, use_admin_client: bool = False) -> list[int]:
         '''Get the group_id of groups committed into Kafka.'''
         kafka_group_reader = get_kafka_group_reader(cluster_config, use_admin_client)
         groups_and_topics = kafka_group_reader.read_groups(list_only=True)
         return list(groups_and_topics.keys())
 
     @classmethod
-    def print_groups(cls, groups, cluster_config):
+    def print_groups(cls, groups: Collection[int], cluster_config: ClusterConfig) -> None:
         print("Consumer Groups:")
         for groupid in groups:
             print(f"\t{groupid}")
@@ -48,7 +55,7 @@ class ListGroups(OffsetManagerBase):
         )
 
     @classmethod
-    def run(cls, args, cluster_config):
+    def run(cls, args: argparse.Namespace, cluster_config: ClusterConfig) -> None:
         groups = set()
         kafka_groups = cls.get_kafka_groups(
             cluster_config,

--- a/kafka_utils/kafka_consumer_manager/commands/list_topics.py
+++ b/kafka_utils/kafka_consumer_manager/commands/list_topics.py
@@ -11,16 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import argparse
 import sys
+from typing import Any
 
 from .offset_manager import OffsetManagerBase
 from kafka_utils.util.client import KafkaToolClient
+from kafka_utils.util.config import ClusterConfig
 
 
 class ListTopics(OffsetManagerBase):
 
     @classmethod
-    def setup_subparser(cls, subparsers):
+    def setup_subparser(cls, subparsers: Any) -> None:
         parser_list_topics = subparsers.add_parser(
             "list_topics",
             description="List topics by consumer group.",
@@ -37,7 +40,7 @@ class ListTopics(OffsetManagerBase):
         parser_list_topics.set_defaults(command=cls.run)
 
     @classmethod
-    def run(cls, args, cluster_config):
+    def run(cls, args: argparse.Namespace, cluster_config: ClusterConfig) -> None:
         # Setup the Kafka client
         client = KafkaToolClient(cluster_config.broker_list)
         client.load_metadata_for_topics()

--- a/kafka_utils/kafka_consumer_manager/commands/offset_advance.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_advance.py
@@ -11,19 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import argparse
 import sys
+from typing import Any
 
 from kafka.errors import UnknownMemberIdError
 
 from .offset_manager import OffsetWriter
 from kafka_utils.util.client import KafkaToolClient
+from kafka_utils.util.config import ClusterConfig
 from kafka_utils.util.offsets import advance_consumer_offsets
 
 
 class OffsetAdvance(OffsetWriter):
 
     @classmethod
-    def setup_subparser(cls, subparsers):
+    def setup_subparser(cls, subparsers: Any) -> None:
         parser_offset_advance = subparsers.add_parser(
             "offset_advance",
             description="Advance consumer offsets for the specified consumer "
@@ -59,7 +62,7 @@ class OffsetAdvance(OffsetWriter):
         parser_offset_advance.set_defaults(command=cls.run)
 
     @classmethod
-    def run(cls, args, cluster_config):
+    def run(cls, args: argparse.Namespace, cluster_config: ClusterConfig) -> None:
         # Setup the Kafka client
         client = KafkaToolClient(cluster_config.broker_list)
         client.load_metadata_for_topics()

--- a/kafka_utils/kafka_consumer_manager/commands/offset_get.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_get.py
@@ -158,7 +158,7 @@ class OffsetGet(OffsetManagerBase):
         return OrderedDict(sorted_offsets)
 
     @classmethod
-    def get_offsets(cls, client: KafkaToolClient, group: int, topics_dict: dict[str, list[int]]) -> dict[str, list[ConsumerPartitionOffsets]]:
+    def get_offsets(cls, client: KafkaToolClient, group: str, topics_dict: dict[str, list[int]]) -> dict[str, list[ConsumerPartitionOffsets]]:
         try:
             return get_consumer_offsets_metadata(
                 client, group, topics_dict, False,

--- a/kafka_utils/kafka_consumer_manager/commands/offset_manager.py
+++ b/kafka_utils/kafka_consumer_manager/commands/offset_manager.py
@@ -11,12 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 import sys
 
 from kazoo.exceptions import NoNodeError
 
 from kafka_utils.kafka_consumer_manager.util import get_kafka_group_reader
 from kafka_utils.kafka_consumer_manager.util import prompt_user_input
+from kafka_utils.util.config import ClusterConfig
 from kafka_utils.util.zookeeper import ZK
 
 
@@ -25,9 +28,9 @@ class OffsetManagerBase:
     @classmethod
     def get_topics_from_consumer_group_id(
         cls,
-        cluster_config,
-        groupid,
-        use_admin_client=False,
+        cluster_config: ClusterConfig,
+        groupid: int,
+        use_admin_client: bool = False,
     ):
         return cls.get_topics_for_group_from_kafka(
             cluster_config, groupid, use_admin_client,
@@ -139,9 +142,9 @@ class OffsetManagerBase:
     @classmethod
     def get_topics_for_group_from_kafka(
         cls,
-        cluster_config,
-        groupid,
-        use_admin_client=False,
+        cluster_config: ClusterConfig,
+        groupid: int,
+        use_admin_client: bool = False,
     ):
         kafka_group_reader = get_kafka_group_reader(
             cluster_config, use_admin_client,

--- a/kafka_utils/kafka_consumer_manager/util.py
+++ b/kafka_utils/kafka_consumer_manager/util.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 import logging
 import sys
 from collections import defaultdict
@@ -257,7 +259,7 @@ class KafkaAdminGroupReader:
             bootstrap_servers=kafka_config.broker_list,
         )
 
-    def read_group(self, groupid):
+    def read_group(self, groupid: int) -> list[str]:
         topics = set()
         group_offsets = self.admin_client.list_consumer_group_offsets(groupid)
         for tp in group_offsets.keys():
@@ -265,7 +267,7 @@ class KafkaAdminGroupReader:
 
         return list(topics)
 
-    def read_groups(self, groupids=None, list_only=False):
+    def read_groups(self, groupids: list[int] | None = None, list_only: bool = False) -> dict[int, list[str]]:
         if groupids is None:
             groupids = self._list_groups()
 
@@ -279,7 +281,7 @@ class KafkaAdminGroupReader:
 
         return groups
 
-    def _list_groups(self):
+    def _list_groups(self) -> list[int]:
         groups_and_protocol_types = self.admin_client.list_consumer_groups()
         return [
             gpt[0]
@@ -301,7 +303,7 @@ class KafkaGroupReader:
         partition = get_group_partition(group_id, partition_count)
         return self.read_groups(partition)[group_id]
 
-    def read_groups(self, partition=None, list_only=False):
+    def read_groups(self, partition=None, list_only: bool = False) -> dict[int, list[str]]:
         self.consumer = KafkaConsumer(
             group_id='offset_monitoring_consumer',
             bootstrap_servers=self.kafka_config.broker_list,
@@ -391,7 +393,7 @@ class KafkaGroupReader:
             self.active_partitions,
         )
 
-    def parse_consumer_offset_message(self, message):
+    def parse_consumer_offset_message(self, message) -> tuple[str, str, int, int]:
         key = message.key
         ((key_schema,), cur) = relative_unpack(b'>h', key, 0)
         if key_schema not in [0, 1]:
@@ -446,7 +448,7 @@ class KafkaGroupReader:
         return self._finished
 
 
-def get_kafka_group_reader(cluster_config, use_admin_client=False):
+def get_kafka_group_reader(cluster_config, use_admin_client=False) -> KafkaGroupReader | KafkaAdminGroupReader:
     if use_admin_client:
         return KafkaAdminGroupReader(cluster_config)
     else:

--- a/kafka_utils/util/__init__.py
+++ b/kafka_utils/util/__init__.py
@@ -11,13 +11,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 import json
 import sys
 from argparse import ArgumentTypeError
 from itertools import groupby
+from typing import Any
+from typing import Callable
+from typing import Iterator
+from typing import TypeVar
+from typing import Union
+
+from typing_extensions import Protocol
+
+T = TypeVar('T')
 
 
-def tuple_replace(tup, *pairs):
+def tuple_replace(tup: tuple[T, ...], *pairs: tuple[int, T]) -> tuple[T, ...]:
     """Return a copy of a tuple with some elements replaced.
 
     :param tup: The tuple to be copied.
@@ -30,7 +41,7 @@ def tuple_replace(tup, *pairs):
     return tuple(tuple_list)
 
 
-def tuple_alter(tup, *pairs):
+def tuple_alter(tup: tuple[T, ...], *pairs: tuple[int, Callable[[T], T]]) -> tuple[T, ...]:
     """Return a copy of a tuple with some elements altered.
 
     :param tup: The tuple to be copied.
@@ -44,7 +55,7 @@ def tuple_alter(tup, *pairs):
     return tuple(tuple_list)
 
 
-def tuple_remove(tup, *items):
+def tuple_remove(tup: tuple[T, ...], *items: T) -> tuple[T, ...]:
     """Return a copy of a tuple with some items removed.
 
     :param tup: The tuple to be copied.
@@ -57,7 +68,7 @@ def tuple_remove(tup, *items):
     return tuple(tuple_list)
 
 
-def positive_int(string):
+def positive_int(string: str) -> int:
     """Convert string to positive integer."""
     error_msg = f'Positive integer required, {string} given.'
     try:
@@ -69,7 +80,7 @@ def positive_int(string):
     return value
 
 
-def positive_nonzero_int(string):
+def positive_nonzero_int(string: str) -> int:
     """Convert string to positive integer greater than zero."""
     error_msg = f'Positive non-zero integer required, {string} given.'
     try:
@@ -81,7 +92,7 @@ def positive_nonzero_int(string):
     return value
 
 
-def positive_float(string):
+def positive_float(string: str) -> float:
     """Convert string to positive float."""
     error_msg = f'Positive float required, {string} given.'
     try:
@@ -93,17 +104,33 @@ def positive_float(string):
     return value
 
 
-def groupsortby(data, key):
+class SupportsLessThan(Protocol):
+    def __lt__(self: T, __other: T) -> bool:
+        ...
+
+
+class SupportsGreaterThan(Protocol):
+    def __gt__(self: T, __other: T) -> bool:
+        ...
+
+
+R = TypeVar('R', bound=Union[SupportsLessThan, SupportsGreaterThan])
+
+
+def groupsortby(data: list[T], key: Callable[[T], R]) -> Iterator[tuple[R, Iterator[T]]]:
     """Sort and group by the same key."""
     return groupby(sorted(data, key=key), key)
 
 
-def dict_merge(set1, set2):
+V = TypeVar('V')
+
+
+def dict_merge(set1: dict[T, V], set2: dict[T, V]) -> dict[T, V]:
     """Joins two dictionaries."""
     return dict(list(set1.items()) + list(set2.items()))
 
 
-def to_h(num, suffix='B'):
+def to_h(num: float | None, suffix: str = 'B') -> str:
     """Converts a byte value in human readable form."""
     if num is None:  # Show None when data is missing
         return "None"
@@ -114,7 +141,7 @@ def to_h(num, suffix='B'):
     return "{:.1f}{}{}".format(num, 'Yi', suffix)
 
 
-def to_int(num):
+def to_int(num: int | None) -> str:
     """
     Converts 'num' to int representation in string
     or to "None" in case of None.
@@ -124,7 +151,7 @@ def to_int(num):
     return f"{num:.0f}"
 
 
-def to_float(num):
+def to_float(num: float | None) -> str:
     """
     Converts 'num' to float representation in string
     or to "None" in case of None.
@@ -134,7 +161,7 @@ def to_float(num):
     return f"{num:.2f}"
 
 
-def format_to_json(data):
+def format_to_json(data: Any) -> str:
     """Converts `data` into json
     If stdout is a tty it performs a pretty print.
     """
@@ -144,6 +171,6 @@ def format_to_json(data):
         return json.dumps(data)
 
 
-def print_json(data):
+def print_json(data: Any) -> None:
     """Converts `data` into json and prints it to stdout."""
     print(format_to_json(data))

--- a/kafka_utils/util/error.py
+++ b/kafka_utils/util/error.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from kafka.structs import OffsetCommitResponsePayload
 
 
 class KafkaToolError(Exception):
@@ -47,12 +48,13 @@ class UnknownPartitions(KafkaToolError):
 class OffsetCommitError(KafkaToolError):
     """Error during offset commit."""
 
-    def __init__(self, topic, partition, error):
+    def __init__(self, topic: str, partition: int, error: str) -> None:
         self.topic = topic
         self.partition = partition
         self.error = error
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
+        assert isinstance(other, (OffsetCommitError, OffsetCommitResponsePayload))
         if all([
             self.topic == other.topic,
             self.partition == other.partition,

--- a/kafka_utils/util/metadata.py
+++ b/kafka_utils/util/metadata.py
@@ -11,11 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 from collections import defaultdict
 
 from kafka.structs import PartitionMetadata
 
 from kafka_utils.util.client import KafkaToolClient
+from kafka_utils.util.config import ClusterConfig
 from kafka_utils.util.zookeeper import ZK
 
 
@@ -23,13 +26,13 @@ LEADER_NOT_AVAILABLE_ERROR = 5
 REPLICA_NOT_AVAILABLE_ERROR = 9
 
 
-def get_topic_partition_metadata(hosts):
+def get_topic_partition_metadata(hosts: list[str]) -> dict[str, dict[int, PartitionMetadata]]:
     """Returns topic-partition metadata from Kafka broker.
 
     kafka-python 1.3+ doesn't include partition metadata information in
     topic_partitions so we extract it from metadata ourselves.
     """
-    topic_partitions = defaultdict(dict)
+    topic_partitions: dict[str, dict[int, PartitionMetadata]] = defaultdict(dict)
 
     kafka_client = KafkaToolClient(hosts, timeout=10)
     resp = kafka_client.send_metadata_request()
@@ -47,7 +50,7 @@ def get_topic_partition_metadata(hosts):
     return topic_partitions
 
 
-def get_unavailable_brokers(zk, partition_metadata):
+def get_unavailable_brokers(zk: ZK, partition_metadata: PartitionMetadata) -> set[int]:
     """Returns the set of unavailable brokers from the difference of replica
     set of given partition to the set of available replicas.
     """
@@ -59,7 +62,11 @@ def get_unavailable_brokers(zk, partition_metadata):
     return expected_replicas - available_replicas
 
 
-def get_topic_partition_with_error(cluster_config, error, fetch_unavailable_brokers=False):
+def get_topic_partition_with_error(
+    cluster_config: ClusterConfig,
+    error: int,
+    fetch_unavailable_brokers: bool = False,
+) -> set[tuple[str, int]] | tuple[set[tuple[str, int]], set[int]]:
     """Fetches the metadata from the cluster and returns the set of
     (topic, partition) tuples containing all the topic-partitions
     currently affected by the specified error. It also fetches unavailable-broker list

--- a/kafka_utils/util/monitoring.py
+++ b/kafka_utils/util/monitoring.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 import logging
 import re
 from collections import namedtuple
@@ -42,7 +44,7 @@ def get_consumer_offsets_metadata(
     group,
     topics,
     raise_on_error=True,
-):
+) -> dict[str, list[ConsumerPartitionOffsets]]:
     """This method:
         * refreshes metadata for the kafka client
         * fetches group offsets

--- a/kafka_utils/util/protocol.py
+++ b/kafka_utils/util/protocol.py
@@ -11,23 +11,29 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 import kafka.protocol.commit
 from kafka.protocol import KafkaProtocol
+from kafka.protocol.api import Response
+from kafka.protocol.commit import GroupCoordinatorRequest_v0
+from kafka.protocol.commit import OffsetCommitRequest_v2
 from kafka.structs import ConsumerMetadataResponse
+from kafka.structs import OffsetCommitRequestPayload
 from kafka.util import group_by_topic_and_partition
 
 
 class KafkaToolProtocol(KafkaProtocol):
 
     @classmethod
-    def encode_offset_commit_request_kafka(cls, group, payloads):
+    def encode_offset_commit_request_kafka(cls, group: str, payloads: list[OffsetCommitRequestPayload]) -> OffsetCommitRequest_v2:
         """
         Encode an OffsetCommitRequest struct
         Arguments:
             group: string, the consumer group you are committing offsets for
             payloads: list of OffsetCommitRequestPayload
         """
-        return kafka.protocol.commit.OffsetCommitRequest[2](
+        return OffsetCommitRequest_v2(
             consumer_group=group,
             consumer_group_generation_id=kafka.protocol.commit.OffsetCommitRequest[2].DEFAULT_GENERATION_ID,
             consumer_id='',
@@ -42,17 +48,17 @@ class KafkaToolProtocol(KafkaProtocol):
                 for topic, topic_payloads in group_by_topic_and_partition(payloads).items()])
 
     @classmethod
-    def encode_consumer_metadata_request(cls, payloads):
+    def encode_consumer_metadata_request(cls, payloads: str) -> GroupCoordinatorRequest_v0:
         """
         Encode a GroupCoordinatorRequest. Note that ConsumerMetadataRequest is
         renamed to GroupCoordinatorRequest in 0.9+. Interface is unchanged
         Arguments:
             payloads: string (consumer group)
         """
-        return kafka.protocol.commit.GroupCoordinatorRequest[0](payloads)
+        return GroupCoordinatorRequest_v0(payloads)
 
     @classmethod
-    def decode_consumer_metadata_response(cls, response):
+    def decode_consumer_metadata_response(cls, response: Response) -> ConsumerMetadataResponse:
         """
         Decode GroupCoordinatorResponse. Note that ConsumerMetadataResponse is
         renamed to GroupCoordinatorResponse in 0.9+

--- a/kafka_utils/util/serialization.py
+++ b/kafka_utils/util/serialization.py
@@ -12,17 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+from typing import Any
 
 
-def load_json(input_data):
+def load_json(input_data: bytes) -> Any:
     data_str = input_data.decode()
 
     return json.loads(data_str)
 
 
-def dump_json(obj):
+def dump_json(obj: Any) -> bytes:
     serialized = json.dumps(obj, sort_keys=True)
 
-    serialized = serialized.encode()
-
-    return serialized
+    return serialized.encode()

--- a/kafka_utils/util/utils.py
+++ b/kafka_utils/util/utils.py
@@ -11,13 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 import importlib
 import inspect
 import os
 import sys
+from types import ModuleType
+from typing import Collection
 
 
-def get_module(module_full_name):
+def get_module(module_full_name: str) -> ModuleType:
     if ':' in module_full_name:
         path, module_name = module_full_name.rsplit(':', 1)
         if not os.path.isdir(path):
@@ -29,7 +33,7 @@ def get_module(module_full_name):
         return importlib.import_module(module_full_name)
 
 
-def child_class(class_types, base_class):
+def child_class(class_types: Collection[type], base_class: type) -> type | None:
     """
     Find the child-most class of `base_class`.
 
@@ -69,7 +73,7 @@ def child_class(class_types, base_class):
         return subclasses.pop()
 
 
-def dynamic_import(module_full_name, base_class):
+def dynamic_import(module_full_name: str, base_class: type) -> type | None:
     module = get_module(module_full_name)
     class_types = [
         class_type

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,19 @@
 [mypy]
 python_version = 3.7
+pretty = true
+show_error_codes = true
+show_error_context = true
+show_column_numbers = true
+disallow_any_generics = true
+disallow_untyped_decorators = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+
+[mypy-kafka_utils.util.*]
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_untyped_calls = true
+warn_unreachable = true
 
 [mypy-humanfriendly.*]
 ignore_missing_imports = true

--- a/setup.py
+++ b/setup.py
@@ -74,4 +74,7 @@ setup(
         "Operating System :: POSIX",
         "Operating System :: MacOS :: MacOS X",
     ],
+    package_data={
+        'kafka_utils': ['util/py.typed'],
+    },
 )

--- a/tests/util/zookeeper_test.py
+++ b/tests/util/zookeeper_test.py
@@ -60,7 +60,7 @@ class TestZK:
             call_list = [
                 mock.call(
                     '/kafka/consumers/some_group/offsets',
-                    '', None, False, False, False
+                    b'', None, False, False, False
                 ),
                 mock.call(
                     '/kafka/consumers/some_group/offsets',


### PR DESCRIPTION
This adds type annotations to all of `kafka_utils.util` and some of `kafka_utils.kafka_consumer_manager.commands`. I started on the latter module before we realized that `kafka_utils.util` was the only module that was meaningfully used.

There's probably more room for better TypedDicts in here (especially in `kafka_utils/util/zookeeper.py`), but I think this is good enough for now.